### PR TITLE
change all stride types to size_t

### DIFF
--- a/include/SZ3/compressor/SZInterpolationCompressor.hpp
+++ b/include/SZ3/compressor/SZInterpolationCompressor.hpp
@@ -308,14 +308,14 @@ namespace SZ {
         template<uint NN = N>
         typename std::enable_if<NN == 1, double>::type
         block_interpolation(T *data, std::array<size_t, N> begin, std::array<size_t, N> end, const PredictorBehavior pb,
-                            const std::string &interp_func, const int direction, uint stride = 1) {
+                            const std::string &interp_func, const int direction, size_t stride = 1) {
             return block_interpolation_1d(data, begin[0], end[0], stride, interp_func, pb);
         }
 
         template<uint NN = N>
         typename std::enable_if<NN == 2, double>::type
         block_interpolation(T *data, std::array<size_t, N> begin, std::array<size_t, N> end, const PredictorBehavior pb,
-                            const std::string &interp_func, const int direction, uint stride = 1) {
+                            const std::string &interp_func, const int direction, size_t stride = 1) {
             double predict_error = 0;
             size_t stride2x = stride * 2;
             const std::array<int, N> dims = dimension_sequences[direction];
@@ -339,7 +339,7 @@ namespace SZ {
         template<uint NN = N>
         typename std::enable_if<NN == 3, double>::type
         block_interpolation(T *data, std::array<size_t, N> begin, std::array<size_t, N> end, const PredictorBehavior pb,
-                            const std::string &interp_func, const int direction, uint stride = 1) {
+                            const std::string &interp_func, const int direction, size_t stride = 1) {
             double predict_error = 0;
             size_t stride2x = stride * 2;
             const std::array<int, N> dims = dimension_sequences[direction];
@@ -383,7 +383,7 @@ namespace SZ {
         template<uint NN = N>
         typename std::enable_if<NN == 4, double>::type
         block_interpolation(T *data, std::array<size_t, N> begin, std::array<size_t, N> end, const PredictorBehavior pb,
-                            const std::string &interp_func, const int direction, uint stride = 1) {
+                            const std::string &interp_func, const int direction, size_t stride = 1) {
             double predict_error = 0;
             size_t stride2x = stride * 2;
             max_error = 0;


### PR DESCRIPTION
Change the type of strides in block_interpolation function declarations to size_t to match the bugfix commit 76794c364f6be4cb865feb4969aa6d7d188558f7.