### PR TITLE
Initialize max_err

### DIFF
--- a/tools/sz3/sz3_smoke_test.cpp
+++ b/tools/sz3/sz3_smoke_test.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     auto dec_data_p = dec_data.data();
     SZ_decompress(conf, cmpData, cmpSize, dec_data_p);
 
-    double max_err;
+    double max_err=0.0;
     for (size_t i = 0; i < conf.num; i++) {
         if (fabs(dec_data[i] - input_data_copy[i]) > max_err) {
             max_err = fabs(dec_data[i] - input_data_copy[i]);


### PR DESCRIPTION
Windows crashes with a runtime error because of max_err not being initialized