### PR TITLE
Make the build chain compatible with native Microsoft windows compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ include(CTest)
 
 option(BUILD_SHARED_LIBS "build shared libraries by default" ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
+if (MSVC)
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif()
 set(default_build_type "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type was set. Setting build type to ${default_build_type}.")
@@ -33,7 +35,11 @@ target_compile_features(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} INTERFACE OpenMP::OpenMP_CXX)
 
-option(SZ3_USE_BUNDLED_ZSTD "prefer the bundled version of Zstd" OFF)
+if (MSVC)
+    option(SZ3_USE_BUNDLED_ZSTD "prefer the bundled version of Zstd" ON)
+else()
+    option(SZ3_USE_BUNDLED_ZSTD "prefer the bundled version of Zstd" OFF)
+endif()
 option(SZ3_DEBUG_TIMINGS "print debug timing information" ON)
 
 if(SZ3_DEBUG_TIMINGS)

--- a/tools/zstd/CMakeLists.txt
+++ b/tools/zstd/CMakeLists.txt
@@ -1,4 +1,9 @@
-add_library(zstd SHARED 
+if (MSVC)
+    set(ZSTD_BUILD_TYPE STATIC)
+else()
+    set(ZSTD_BUILD_TYPE SHARED)
+endif()
+add_library(zstd ${ZSTD_BUILD_TYPE}
   ./common/entropy_common.c
   ./common/pool.c
   ./common/threading.c


### PR DESCRIPTION
I am not a cmake expert. Please feel free to modify things.

I had to pass the /bigobj flag and to build the provided zstd statically to get it working.

The sz3_smoke_test passes.

The commands I used:
 
```
mkdir build
cd build
cmake ..\ -G"NMake Makefiles"
nmake
nmake install
```