### PR TITLE
Use portable 64-bit integer types.

### DIFF
--- a/tools/H5Z-SZ3/include/H5Z_SZ3.hpp
+++ b/tools/H5Z-SZ3/include/H5Z_SZ3.hpp
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <cstdint>
 
 
 
@@ -77,10 +78,10 @@ void init_dims_chunk(int dim, hsize_t dims[5], hsize_t chunk[5], size_t nbEle, s
 double bytesToDouble(unsigned char* bytes);
 void doubleToBytes(unsigned char *b, double num);
 
-void longToBytes_bigEndian(unsigned char *b, unsigned long num) ;
+void longToBytes_bigEndian(unsigned char *b, uint64_t num) ;
 
 int bytesToInt_bigEndian(unsigned char* bytes);
-long bytesToLong_bigEndian(unsigned char* b);
+int64_t bytesToLong_bigEndian(unsigned char* b);
 
 void detectSysEndianType();
 void symTransform_8bytes(unsigned char data[8]);

--- a/tools/H5Z-SZ3/src/H5Z_SZ3.cpp
+++ b/tools/H5Z-SZ3/src/H5Z_SZ3.cpp
@@ -76,7 +76,7 @@ const void *H5PLget_plugin_info(void) {
 	switch(newDim)
 	{		
 		case 1:
-			longToBytes_bigEndian(bytes, (unsigned long)r1);
+			longToBytes_bigEndian(bytes, (uint64_t) r1);
 			(*new_cd_values)[2] = bytesToInt_bigEndian(bytes);
 			(*new_cd_values)[3] = bytesToInt_bigEndian(&bytes[4]);	
 			if(old_cd_nelmts==0)
@@ -644,7 +644,7 @@ void SZ_cdArrayToMetaData(size_t cd_nelmts, const unsigned int cd_values[], int*
         if(sizeof(size_t)==4)
             *r1 = (unsigned int) SZ::bytesToInt64_bigEndian(bytes);
         else
-            *r1 = (unsigned long) SZ::bytesToInt64_bigEndian(bytes);
+            *r1 = (uint64_t) SZ::bytesToInt64_bigEndian(bytes);
         *r2 = *r3 = *r4 = *r5 = 0;
         break;
     case 2:
@@ -701,7 +701,7 @@ void SZ_cdArrayToMetaDataErr(size_t cd_nelmts, const unsigned int cd_values[], i
 void SZ_copymetaDataToCdArray(size_t* cd_nelmts, unsigned int *cd_values, int dataType, size_t r5, size_t r4, size_t r3, size_t r2, size_t r1)
 {
     unsigned char bytes[8] = {0};
-    unsigned long size;
+    uint64_t size;
     int dim = computeDimension(r5, r4, r3, r2, r1);
     cd_values[0] = dim;
     cd_values[1] = dataType;	//0: FLOAT ; 1: DOUBLE ; 2,3,4,....: INTEGER....
@@ -709,7 +709,7 @@ void SZ_copymetaDataToCdArray(size_t* cd_nelmts, unsigned int *cd_values, int da
     switch(dim)
     {
     case 1:
-        size = (unsigned long)r1;
+        size = (uint64_t) r1;
         SZ::int64ToBytes_bigEndian(bytes, size);
         cd_values[2] = SZ::bytesToInt32_bigEndian(bytes);
         cd_values[3] = SZ::bytesToInt32_bigEndian(&bytes[4]);
@@ -1095,7 +1095,7 @@ int filterDimension(size_t r5, size_t r4, size_t r3, size_t r2, size_t r1, size_
 	
 }
 
-inline void longToBytes_bigEndian(unsigned char *b, unsigned long num) 
+inline void longToBytes_bigEndian(unsigned char *b, uint64_t num) 
 {
 	b[0] = (unsigned char)(num>>56);
 	b[1] = (unsigned char)(num>>48);
@@ -1136,9 +1136,9 @@ inline int bytesToInt_bigEndian(unsigned char* bytes)
 /**
  * @endianType: refers to the endian_type of unsigned char* b.
  * */
-inline long bytesToLong_bigEndian(unsigned char* b) {
-	long temp = 0;
-	long res = 0;
+inline int64_t bytesToLong_bigEndian(unsigned char* b) {
+	int64_t temp = 0;
+	int64_t res = 0;
 
 	res <<= 8;
 	temp = b[0] & 0xff;

--- a/tools/H5Z-SZ3/test/convertBinToHDF5.cpp
+++ b/tools/H5Z-SZ3/test/convertBinToHDF5.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h> 
 #include <stdlib.h>
 #include <string.h>
+#include <cstdint>
 #include "hdf5.h"
 
 
@@ -183,8 +184,8 @@ int main(int argc, char* argv[]) {
 	else if(strcmp(datatype, "-i64") == 0){
         	FILE *f;                                          		
                 f = fopen(infile, "rb");
-                long *data = (long*)malloc(nbEle*sizeof(long));
-                fread(data, sizeof(long), nbEle, f);
+                int64_t *data = (int64_t*)malloc(nbEle*sizeof(int64_t));
+                fread(data, sizeof(int64_t), nbEle, f);
                 fclose(f);
         
 		dataset_id = H5Dcreate2(file_id, database, H5T_STD_I64LE, dataspace_id, 

--- a/tools/H5Z-SZ3/test/dsz3FromHDF5.cpp
+++ b/tools/H5Z-SZ3/test/dsz3FromHDF5.cpp
@@ -214,7 +214,7 @@ int main(int argc, char * argv[])
 			else if(dsize==8)
 			{
 				printf("data type: unsigned long\n");
-				unsigned long* data = (unsigned long*)malloc(sizeof(unsigned long)*nbEle);		
+				uint64_t* data = (uint64_t*)malloc(sizeof(uint64_t)*nbEle);
 				if(dorder==H5T_ORDER_LE)	
 					status = H5Dread(dset, H5T_STD_U64LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
 				else
@@ -277,7 +277,7 @@ int main(int argc, char * argv[])
 			else if(dsize==8)
 			{
 				printf("data type: long\n");
-				long *data = (long*)malloc(sizeof(long)*nbEle);
+				int64_t *data = (int64_t*)malloc(sizeof(int64_t)*nbEle);
 				if(dorder==H5T_ORDER_LE)	
 					status = H5Dread(dset, H5T_STD_I64LE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
 				else

--- a/tools/H5Z-SZ3/test/print_h5repack_args.cpp
+++ b/tools/H5Z-SZ3/test/print_h5repack_args.cpp
@@ -1,5 +1,6 @@
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 #include <cmath>
 #include <cstring>
 
@@ -21,7 +22,7 @@ int dataEndianType = LITTLE_ENDIAN_DATA;
 typedef union ldouble
 {
     double value;
-    unsigned long lvalue;
+    uint64_t lvalue;
     unsigned char byte[8];
 } ldouble;
 


### PR DESCRIPTION
use int64_t and uint64_t instead of long and unsigned long to make sure there is no ambiguity among different platforms and/or compilers.