### PR TITLE
python: load library from a sensible default path, if not provided

### DIFF
--- a/tools/pysz/pysz.py
+++ b/tools/pysz/pysz.py
@@ -1,6 +1,8 @@
+import sys
 import ctypes
 from ctypes.util import find_library
 import numpy as np
+
 
 """
 Python API for SZ2/SZ3
@@ -8,11 +10,18 @@ Python API for SZ2/SZ3
 
 
 class SZ:
-    def __init__(self, szpath):
+    def __init__(self, szpath=None):
         """
         init SZ
         :param szpath: the path to SZ dynamic library
         """
+
+        if szpath is None:
+            szpath = {
+             "darwin": "libSZ3c.dylib",
+             "windows": "SZ3c.dll",
+            }.get(sys.platform, "libSZ3c.so")
+
         self.sz = ctypes.cdll.LoadLibrary(szpath)
 
         self.sz.SZ_compress_args.argtypes = (ctypes.c_int, ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t),


### PR DESCRIPTION
This is a trivial patch that simplifies python bindings usage when the library has been installed on a system.