### PR TITLE
fix missing uint8_t with GCC 13

### DIFF
--- a/include/SZ3/utils/Config.hpp
+++ b/include/SZ3/utils/Config.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <vector>
 #include <numeric>
+#include <cstdint>
 #include "SZ3/def.hpp"
 #include "MemoryUtil.hpp"
 #include "SZ3/utils/inih/INIReader.h"


### PR DESCRIPTION
I recently ran into compile errors because uint8_t not being defined. A change that happened a short time ago, that GCC was upgraded from 12.x to 13.1.1