### PR TITLE
Fix SZFastFrontend::size_est() returning undefined value

### DIFF
--- a/include/SZ3/frontend/SZFastFrontend.hpp
+++ b/include/SZ3/frontend/SZFastFrontend.hpp
@@ -139,6 +139,7 @@ namespace SZ3 {
             if (reg_unpredictable_data != nullptr) {
                 free(reg_unpredictable_data);
                 reg_unpredictable_data = nullptr;
+                reg_unpredictable_data_pos = nullptr;
             }
 //            if (unpred_data_buffer != nullptr) {
 //                free(unpred_data_buffer);
@@ -596,7 +597,7 @@ namespace SZ3 {
         int *reg_params_type = nullptr;
         float *reg_unpredictable_data = nullptr;
         float *reg_params = nullptr;
-        float *reg_unpredictable_data_pos;
+        float *reg_unpredictable_data_pos = nullptr;
 
         SZMETA::meanInfo<T> mean_info;
         int capacity = 0; // not used, capacity is controlled by quantizer


### PR DESCRIPTION
`reg_unpredictable_data_pos` is uninitialised, which leads to a crash here: https://github.com/szcompressor/SZ3/blob/13e79072ede6a480d4db217e875ce006da90d6af/include/SZ3/compressor/SZGeneralCompressor.hpp#L37

This is because `bufferSize` depends on `SZFastFrontend::size_est()` which depends on the difference between `reg_unpredictable_data` and `reg_unpredictable_data_pos`