### PR TITLE
Add support for 32bit systems by falling back to `std::unordered_map`

### DIFF
--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -6,7 +6,10 @@
 #include "SZ3/utils/ByteUtil.hpp"
 #include "SZ3/utils/MemoryUtil.hpp"
 #include "SZ3/utils/Timer.hpp"
-#include "SZ3/utils/ska_hash/unordered_map.hpp"
+#include <cstdint>
+#if INTPTR_MAX == INT64_MAX // 64bit system
+    #include "SZ3/utils/ska_hash/unordered_map.hpp"
+#endif // INTPTR_MAX == INT64_MAX
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
@@ -525,7 +528,12 @@ namespace SZ3 {
             T max = s[0];
             offset = s[0]; //offset is min
 
-            ska::unordered_map<T, size_t> frequency;
+            #if INTPTR_MAX == INT64_MAX // 64bit system
+                ska::unordered_map<T, size_t> frequency;
+            #else // most likely 32bit system
+                std::unordered_map<T, size_t> frequency;
+            #endif // INTPTR_MAX == INT64_MAX
+
             for (size_t i = 0; i < length; i++) {
                 frequency[s[i]]++;
             }


### PR DESCRIPTION
Compiling SZ3 on 32bit systems (wasm32 in my use case) fails because of the ska_hash implementation, which expects that `size_t` is 64b wide. While there have been attempts to port ska_hash to 32 bits, e.g. in https://github.com/skarupke/flat_hash_map/pull/18, pulling in those changes would place the maintenance burden on SZ3.

In this PR, I'm instead suggesting a simpler solution by falling back to the `std::unordered_map` implementation on non-64bit systems, where `ska::unordered_map` is not available. This immediately unlocks 32bit support with a minimal code change.