### PR TITLE
Fix absolute error bound to 0.0 for lossless compression

### DIFF
--- a/include/SZ3/utils/Statistic.hpp
+++ b/include/SZ3/utils/Statistic.hpp
@@ -30,6 +30,10 @@ inline double computeABSErrBoundFromPSNR(double psnr, double threshold, double v
 
 template <class T>
 void calAbsErrorBound(Config &conf, const T *data, T range = 0) {
+    if (conf.cmprAlgo == ALGO_LOSSLESS) {
+        conf.errorBoundMode = EB_ABS;
+        conf.absErrorBound = 0.0;
+    }
     if (conf.errorBoundMode != EB_ABS) {
         if (conf.errorBoundMode == EB_REL) {
             conf.errorBoundMode = EB_ABS;


### PR DESCRIPTION
If a non-zero error bound is passed in lossless mode, Zstd compression is skipped entirely, i.e. only the config is encoded but not the data. This fix ensures that the compression path in the dispatcher is always taken (and that the config makes sense).