### PR TITLE
Fix UB for small array compression

### DIFF
--- a/include/SZ3/api/sz.hpp
+++ b/include/SZ3/api/sz.hpp
@@ -92,8 +92,8 @@ template <class T>
 char *SZ_compress(const SZ3::Config &config, const T *data, size_t &cmpSize) {
     using namespace SZ3;
 
-    size_t bufferLen = config.size_est() + 2 * config.num * sizeof(T);
-    bufferLen = (bufferLen < 1024) ? 1024 : bufferLen;
+    // Ensure that the buffer can always hold the config and the lossless fallback
+    size_t bufferLen = config.size_est() + ZSTD_compressBound(config.num * sizeof(T));
     auto buffer = new char[bufferLen];
     cmpSize = SZ_compress(config, data, buffer, bufferLen);
 

--- a/include/SZ3/api/sz.hpp
+++ b/include/SZ3/api/sz.hpp
@@ -92,7 +92,8 @@ template <class T>
 char *SZ_compress(const SZ3::Config &config, const T *data, size_t &cmpSize) {
     using namespace SZ3;
 
-    size_t bufferLen = 2 * config.num * sizeof(T);
+    size_t bufferLen = config.size_est() + 2 * config.num * sizeof(T);
+    bufferLen = (bufferLen < 1024) ? 1024 : bufferLen;
     auto buffer = new char[bufferLen];
     cmpSize = SZ_compress(config, data, buffer, bufferLen);
 


### PR DESCRIPTION
MUST FIX (first line):

The `bufferLen` needs to include `config.size_est()`, otherwise for small arrays the config saving will write out of bounds (and in my case overwrite the config dims capacity which leads to some fiendishly hard to debug double frees).

maybe fix (second line):

For small arrays, even with this fix, lossless compression (so just Zstd) can still run out of space and throw an exception. It would be nice to give Zstd a bit of a buffer here so that it's not trivial to trigger the exception.