### PR TITLE
Guarantee that decompress doesn't modify the compressed data

### DIFF
--- a/include/SZ3/api/sz.hpp
+++ b/include/SZ3/api/sz.hpp
@@ -119,7 +119,7 @@ char *SZ_compress(const SZ3::Config &config, const T *data, size_t &cmpSize) {
 
  */
 template <class T>
-void SZ_decompress(SZ3::Config &config, char *cmpData, size_t cmpSize, T *&decData) {
+void SZ_decompress(SZ3::Config &config, const char *cmpData, size_t cmpSize, T *&decData) {
     using namespace SZ3;
     auto cmpConfPos = reinterpret_cast<const uchar *>(cmpData);
     config.load(cmpConfPos);
@@ -160,7 +160,7 @@ void SZ_decompress(SZ3::Config &config, char *cmpData, size_t cmpSize, T *&decDa
  float decompressedData = SZ_decompress(conf, cmpData, cmpSize)
  */
 template <class T>
-T *SZ_decompress(SZ3::Config &config, char *cmpData, size_t cmpSize) {
+T *SZ_decompress(SZ3::Config &config, const char *cmpData, size_t cmpSize) {
     using namespace SZ3;
     T *decData = nullptr;
     SZ_decompress<T>(config, cmpData, cmpSize, decData);


### PR DESCRIPTION
https://github.com/szcompressor/SZ3/blob/88095a8bb862b833191388c7f1196a67e2350426/include/SZ3/api/impl/SZImpl.hpp#L22

already provides this guarantee, so let's also provide it in the API