### PR TITLE
Fix NaN handling in the linear quantizer

### DIFF
--- a/include/SZ3/quantizer/LinearQuantizer.hpp
+++ b/include/SZ3/quantizer/LinearQuantizer.hpp
@@ -46,12 +46,13 @@ class LinearQuantizer : public concepts::QuantizerInterface<T, int> {
                 quant_index_shifted = this->radius + half_index;
             }
             T decompressed_data = pred + quant_index * this->error_bound;
-            if (fabs(decompressed_data - data) > this->error_bound) {
-                unpred.push_back(data);
-                return 0;
-            } else {
+            // if data is NaN, the error is NaN, and NaN <= error_bound is false
+            if (fabs(decompressed_data - data) <= this->error_bound) {
                 data = decompressed_data;
                 return quant_index_shifted;
+            } else {
+                unpred.push_back(data);
+                return 0;
             }
         } else {
             unpred.push_back(data);
@@ -81,13 +82,14 @@ class LinearQuantizer : public concepts::QuantizerInterface<T, int> {
                 quant_index_shifted = this->radius + half_index;
             }
             T decompressed_data = pred + quant_index * this->error_bound;
-            if (fabs(decompressed_data - ori) > this->error_bound) {
+            // if data is NaN, the error is NaN, and NaN <= error_bound is false
+            if (fabs(decompressed_data - ori) <= this->error_bound) {
+                dest = decompressed_data;
+                return quant_index_shifted;
+            } else {
                 unpred.push_back(ori);
                 dest = ori;
                 return 0;
-            } else {
-                dest = decompressed_data;
-                return quant_index_shifted;
             }
         } else {
             unpred.push_back(ori);


### PR DESCRIPTION
SZ3 currently doesn't handle NaNs correctly and returns interpolated data for them.

https://github.com/szcompressor/SZ3/blob/cd4a2611b47b4989e06ab863f60e99df8ce03aae/include/SZ3/quantizer/LinearQuantizer.hpp#L49

is at fault, since for NaN data, the error is NaN, and NaN > error_bound is false, so the quantizer assumes the interpolated prediction is good. By flipping the comparison to NaN <= error_bound, we get the expected behavior of falling back to unpredictable values.