### PR TITLE
Add option to use std unordered_map and fix ubsan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include(GNUInstallDirs)
 include(CTest)
 
 option(BUILD_SHARED_LIBS "build shared libraries by default" ON)
+option(USE_HASH_MAP_STD "use std unordered_map, not ska" ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")

--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -513,7 +513,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
         T max = s[0];
         offset = s[0];  // offset is min
 
-#if INTPTR_MAX == INT64_MAX  // 64bit system
+#if INTPTR_MAX == INT64_MAX && USE_HASH_MAP_STD // 64bit system
         ska::unordered_map<T, size_t> frequency;
 #else   // most likely 32bit system
         std::unordered_map<T, size_t> frequency;

--- a/include/SZ3/utils/ska_hash/unordered_map.hpp
+++ b/include/SZ3/utils/ska_hash/unordered_map.hpp
@@ -424,7 +424,7 @@ public:
             return;
         EntryPointer * new_buckets(&*BucketAllocatorTraits::allocate(*this, num_buckets + 1));
         EntryPointer * end_it = new_buckets + static_cast<ptrdiff_t>(num_buckets + 1);
-        *new_buckets = EntryPointer(nullptr) + ptrdiff_t(1);
+        *new_buckets = EntryPointer(1);
         ++new_buckets;
         std::fill(new_buckets, end_it, nullptr);
         std::swap(entries, new_buckets);


### PR DESCRIPTION
I use in my application your library and I have a problem with ubsan in line `*new_buckets = EntryPointer(nullptr) + ptrdiff_t(1);`. I would like to have option to turn off ska::unordered_map to avoid possible future problems and try to fix this behaviour.