### PR TITLE
Rename the flag ENABLE_GSL into SZ3_ENABLE_GSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif ()
 
 find_package(GSL)
 if (GSL_FOUND)
-    target_compile_definitions(${PROJECT_NAME} INTERFACE -DENABLE_GSL="TRUE")
+    target_compile_definitions(${PROJECT_NAME} INTERFACE -DSZ3_ENABLE_GSL)
     target_link_libraries(${PROJECT_NAME} INTERFACE GSL::gsl)
 endif ()
 

--- a/include/SZ3/preprocessor/Wavelet.hpp
+++ b/include/SZ3/preprocessor/Wavelet.hpp
@@ -1,7 +1,7 @@
 #ifndef SZ3_WAVELET_HPP
 #define SZ3_WAVELET_HPP
 
-#ifdef ENABLE_GSL
+#ifdef SZ3_ENABLE_GSL
 
 #include "SZ3/preprocessor/PreProcessor.hpp"
 #include <gsl/gsl_wavelet.h>


### PR DESCRIPTION
Since this is exported, we better use a more specific name.
ENABLE_GSL could interfere with GSL related flags from other projects.