### PR TITLE
Introduce SZ3::unordered_map for wasm32 compatibility

### DIFF
--- a/include/SZ3/decomposition/SZBioMDDecomposition.hpp
+++ b/include/SZ3/decomposition/SZBioMDDecomposition.hpp
@@ -9,6 +9,7 @@
 #include <list>
 
 #include "SZ3/utils/Config.hpp"
+#include "SZ3/utils/Collections.hpp"
 
 namespace SZ3 {
 
@@ -106,7 +107,7 @@ class SZBioMDDecomposition : public concepts::DecompositionInterface<T, int, N> 
                 }
             }
         }
-        ska::unordered_map<int, size_t> frequency;
+        unordered_map<int, size_t> frequency;
         for (size_t i = 0; i < sites.size(); i++) {
             frequency[sites[i]]++;
         }

--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -8,9 +8,7 @@
 #include "SZ3/utils/ByteUtil.hpp"
 #include "SZ3/utils/MemoryUtil.hpp"
 #include "SZ3/utils/Timer.hpp"
-#if INTPTR_MAX == INT64_MAX  // 64bit system
-#include "SZ3/utils/ska_hash/unordered_map.hpp"
-#endif  // INTPTR_MAX == INT64_MAX
+#include "SZ3/utils/Collections.hpp"
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
@@ -18,7 +16,6 @@
 #include <iostream>
 #include <map>
 #include <set>
-#include <unordered_map>
 #include <unordered_set>
 
 namespace SZ3 {
@@ -520,11 +517,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
         T max = s[0];
         offset = s[0];  // offset is min
 
-#if (SZ3_USE_SKA_HASH) && (INTPTR_MAX == INT64_MAX)  // use ska for 64bit system
-        ska::unordered_map<T, size_t> frequency;
-#else   // most likely 32bit system
-        std::unordered_map<T, size_t> frequency;
-#endif  // INTPTR_MAX == INT64_MAX
+        unordered_map<T, size_t> frequency;
 
         for (size_t i = 0; i < length; i++) {
             frequency[s[i]] += 1;

--- a/include/SZ3/encoder/HuffmanEncoderV2.hpp
+++ b/include/SZ3/encoder/HuffmanEncoderV2.hpp
@@ -12,7 +12,7 @@
 #include "SZ3/utils/ByteUtil.hpp"
 #include "SZ3/utils/MemoryUtil.hpp"
 #include "SZ3/utils/Timer.hpp"
-#include "SZ3/utils/ska_hash/unordered_map.hpp"
+#include "SZ3/utils/Collections.hpp"
 
 namespace SZ3 {
 template <class T>
@@ -91,8 +91,8 @@ private:
 
         std::vector<uchar> veclen;
         std::vector<int> veccode;
-        ska::unordered_map<size_t, uchar> mplen;
-        ska::unordered_map<size_t, int> mpcode;
+        unordered_map<size_t, uchar> mplen;
+        unordered_map<size_t, int> mpcode;
         //            std::unordered_map<size_t,uchar> mplen;
         //            std::unordered_map<size_t,int> mpcode;
         //            std::map<size_t,uchar> mplen;
@@ -128,7 +128,7 @@ private:
         T maxval;
         std::vector<Node> ht;
         std::vector<size_t> vecfreq;
-        ska::unordered_map<T, size_t> mpfreq;
+        unordered_map<T, size_t> mpfreq;
         //            std::unordered_map<T,size_t> mpfreq;
         //            std::map<T,size_t> mpfreq;
 
@@ -278,7 +278,7 @@ public:
             //                tree.mplen.reserve(num_bin);
             //                tree.mpcode.reserve(num_bin);
 
-            //                ska::unordered_map<T,size_t> freq;
+            //                unordered_map<T,size_t> freq;
             //                std::unordered_map<T,size_t> freq;
             std::map<T, size_t> freq;
             //                freq.reserve(num_bin);

--- a/include/SZ3/utils/Collections.hpp
+++ b/include/SZ3/utils/Collections.hpp
@@ -1,0 +1,15 @@
+#if INTPTR_MAX == INT64_MAX  // use ska for 64bit system
+#include "SZ3/utils/ska_hash/unordered_map.hpp"
+#else   // most likely 32bit system
+#include <unordered_map>
+#endif  // INTPTR_MAX == INT64_MAX
+
+namespace SZ3 {
+
+#if (SZ3_USE_SKA_HASH) && (INTPTR_MAX == INT64_MAX)  // use ska for 64bit system
+    using ska::unordered_map;
+#else   // most likely 32bit system
+    using std::unordered_map;
+#endif  // INTPTR_MAX == INT64_MAX
+
+}


### PR DESCRIPTION
SZ3.3 broke wasm32 compilation by bringing back some usages of ska::unordered_map. This PR tries to avoid such breakages in the future by centralizing the switch between ska::unordered_map on 64bit platforms and std::unordered_map elsewhere.

@ayzk If this change looks good, could you please add it to a new patch release?