### PR TITLE
fix: propagate HDF5_IS_PARALLEL to parent scope for SZ3Config

### DIFF
--- a/tools/H5Z-SZ3/CMakeLists.txt
+++ b/tools/H5Z-SZ3/CMakeLists.txt
@@ -21,6 +21,7 @@ if (${HDF5_IS_PARALLEL})
     target_link_libraries(hdf5sz3
             PUBLIC MPI::MPI_CXX)
 endif ()
+set(HDF5_IS_PARALLEL ${HDF5_IS_PARALLEL} PARENT_SCOPE)
 
 target_include_directories(hdf5sz3
         PUBLIC


### PR DESCRIPTION
## Summary

Fixes Copilot review comment on PR #126: `HDF5_IS_PARALLEL` was not available in the parent scope when `configure_package_config_file` processes `SZ3Config.cmake.in`.

## Changes

- **`tools/H5Z-SZ3/CMakeLists.txt`**: Added `set(HDF5_IS_PARALLEL ${HDF5_IS_PARALLEL} PARENT_SCOPE)` to propagate the variable set by `find_package(HDF5)` to the parent scope.

## Verified

Both import methods tested:
- find_package(SZ3) + SZ3::hdf5sz3: PASS
- FetchContent + hdf5sz3: PASS