### PR TITLE
Fix Config::load reading one byte past the end of the config

### DIFF
--- a/include/SZ3/utils/Config.hpp
+++ b/include/SZ3/utils/Config.hpp
@@ -359,9 +359,13 @@ class Config {
      * @param c Pointer to the byte array.
      */
     void load(const unsigned char*& c) {
+        const unsigned char* c0 = c;
         uchar confSize = 0;
         read(confSize, c);
-        auto c1 = c + confSize;
+        // `confSize` is the total size of the serialized config, including this length-prefix byte
+        // (see save()). The end of the config is therefore c0 + confSize, not c + confSize: the latter
+        // is one byte too far because `c` has already advanced past the prefix byte.
+        auto c1 = c0 + confSize;
 
         read(N, c);
         uint8_t bitWidth;


### PR DESCRIPTION
### Problem

`Config::save` writes the config size as `confSize = c - c0`, i.e. the **total** size of the serialized config including the one-byte length prefix it reserves at the start.

In `Config::load`, the end pointer is computed as `c + confSize` **after** the prefix byte has already been read, so it ends up one byte past the real end of the config blob:

```cpp
read(confSize, c);        // c now points just after the 1-byte prefix
auto c1 = c + confSize;   // == c0 + 1 + confSize  -> one byte too far
```

The `if (c < c1)` guards that read the optional trailing fields then use a boundary that is one byte too far. For a config that does not contain all of the trailing fields, this makes `load` read one field past the end of the config.

### Fix

Compute the end of the config relative to its start:

```cpp
const unsigned char* c0 = c;
read(confSize, c);
auto c1 = c0 + confSize;
```

No format change; this only corrects the in-memory end pointer used by `load`.

### Context

Found while integrating SZ3 as an experimental compression codec in ClickHouse: https://github.com/ClickHouse/ClickHouse/pull/108788
