### PR TITLE
Bounds-check decompression against corrupted input

### DIFF
--- a/include/SZ3/api/impl/SZDispatcher.hpp
+++ b/include/SZ3/api/impl/SZDispatcher.hpp
@@ -79,7 +79,9 @@ template <class T, uint N>
 void SZ_decompress_dispatcher(Config &conf, const uchar *cmpData, size_t cmpSize, T *decData) {
     if (conf.cmprAlgo == ALGO_LOSSLESS) {
         auto zstd = Lossless_zstd();
-        size_t decDataSize = 0;
+        /// decData is a pre-allocated buffer of conf.num elements; pass its capacity so the lossless decoder
+        /// can reject a payload that claims a larger decompressed size before writing past the buffer.
+        size_t decDataSize = conf.num * sizeof(T);
         auto decDataPos = reinterpret_cast<uchar *>(decData);
         zstd.decompress(cmpData, cmpSize, decDataPos, decDataSize);
         if (decDataSize != conf.num * sizeof(T)) {

--- a/include/SZ3/api/impl/SZImplOMP.hpp
+++ b/include/SZ3/api/impl/SZImplOMP.hpp
@@ -121,14 +121,22 @@ void SZ_decompress_OMP(Config& conf, const uchar* cmpData, size_t cmpSize, T* de
 #ifdef _OPENMP
 
     auto cmpr_data_pos = cmpData;
+    const uchar* const cmp_end = cmpData + cmpSize;
     int nThreads = 1;
+    // Everything below is read from untrusted data; bound every read against the end of the buffer.
+    if (static_cast<size_t>(cmp_end - cmpr_data_pos) < sizeof(nThreads))
+        throw std::out_of_range("SZ3 OMP: truncated thread count");
     read(nThreads, cmpr_data_pos);
+    // Each per-thread config and size entry occupies at least one byte, so the thread count can not exceed
+    // the size of the compressed buffer.
+    if (nThreads <= 0 || static_cast<size_t>(nThreads) > cmpSize)
+        throw std::out_of_range("SZ3 OMP: invalid thread count");
     omp_set_num_threads(nThreads);
     printf("OpenMP enabled for decompression, threads = %d\n", nThreads);
 
     std::vector<Config> conf_t(nThreads);
     for (int i = 0; i < nThreads; i++) {
-        conf_t[i].load(cmpr_data_pos);
+        conf_t[i].load(cmpr_data_pos, static_cast<size_t>(cmp_end - cmpr_data_pos));
     }
 
     if (conf_t[0].sz3MagicNumber != SZ3_MAGIC_NUMBER) {
@@ -145,12 +153,19 @@ void SZ_decompress_OMP(Config& conf, const uchar* cmpData, size_t cmpSize, T* de
 
     std::vector<size_t> cmp_start_t, cmp_size_t;
     cmp_size_t.resize(nThreads);
+    if (static_cast<size_t>(cmp_end - cmpr_data_pos) < static_cast<size_t>(nThreads) * sizeof(size_t))
+        throw std::out_of_range("SZ3 OMP: truncated per-thread sizes");
     read(cmp_size_t.data(), nThreads, cmpr_data_pos);
     auto cmpr_data_p = cmpr_data_pos;
 
     cmp_start_t.resize(nThreads + 1);
     cmp_start_t[0] = 0;
+    // The per-thread payloads follow back-to-back and must all fit in the remaining buffer. Build the running
+    // offsets with an overflow-safe bound so a crafted size can not point a thread's slice out of bounds.
+    const size_t payload_avail = static_cast<size_t>(cmp_end - cmpr_data_p);
     for (int i = 1; i <= nThreads; i++) {
+        if (cmp_size_t[i - 1] > payload_avail - cmp_start_t[i - 1])
+            throw std::out_of_range("SZ3 OMP: per-thread compressed sizes exceed the buffer");
         cmp_start_t[i] = cmp_start_t[i - 1] + cmp_size_t[i - 1];
     }
 

--- a/include/SZ3/api/sz.hpp
+++ b/include/SZ3/api/sz.hpp
@@ -119,6 +119,12 @@ void SZ_decompress(SZ3::Config& config, const char* cmpData, size_t cmpSize, T*&
 
     auto cmpDataPos = reinterpret_cast<const uchar*>(cmpData);
 
+    // Header layout: magic number (4) + data version (4) + compressed payload size (8) = 16 bytes.
+    if (cmpSize < 16)
+    {
+        throw std::out_of_range("SZ3: compressed data is smaller than the header");
+    }
+
     read(config.sz3MagicNumber, cmpDataPos);
     if (config.sz3MagicNumber != SZ3_MAGIC_NUMBER) {
         throw std::invalid_argument("magic number mismatch, the input data is not compressed by SZ3");
@@ -137,8 +143,13 @@ void SZ_decompress(SZ3::Config& config, const char* cmpData, size_t cmpSize, T*&
     uint64_t cmpDataSize = 0;
     read(cmpDataSize, cmpDataPos);
 
+    // The compressed payload is followed by the serialized config; both must fit in the remaining bytes.
+    if (cmpDataSize > cmpSize - 16)
+    {
+        throw std::out_of_range("SZ3: compressed payload size exceeds the buffer");
+    }
     auto cmpConfPos = cmpDataPos + cmpDataSize;
-    config.load(cmpConfPos);
+    config.load(cmpConfPos, cmpSize - 16 - cmpDataSize);
 
     if (decData == nullptr) {
         decData = new T[config.num];

--- a/include/SZ3/compressor/SZGenericCompressor.hpp
+++ b/include/SZ3/compressor/SZGenericCompressor.hpp
@@ -73,7 +73,8 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
         encoder.load(bufferPos, bufferSize);
 
         size_t quant_inds_size = 0;
-        read(quant_inds_size, bufferPos);
+        // Read the count with the bounded overload so a truncated buffer can not be read past its end.
+        read(quant_inds_size, bufferPos, bufferSize);
         auto quant_inds = encoder.decode(bufferPos, quant_inds_size);
         encoder.postprocess_decode();
 

--- a/include/SZ3/compressor/SZGenericCompressor.hpp
+++ b/include/SZ3/compressor/SZGenericCompressor.hpp
@@ -1,7 +1,9 @@
 #ifndef SZ3_COMPRESSOR_TYPE_ONE_HPP
 #define SZ3_COMPRESSOR_TYPE_ONE_HPP
 
+#include <cstdlib>
 #include <cstring>
+#include <memory>
 
 #include "SZ3/compressor/Compressor.hpp"
 #include "SZ3/decomposition/Decomposition.hpp"
@@ -76,6 +78,11 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
         size_t bufferSize = 4096 + conf.size_est() + ZSTD_compressBound(conf.num * sizeof(T));
         lossless.decompress(cmpData, cmpSize, buffer, bufferSize);
 
+        // The lossless layer allocated `buffer` with malloc. Own it with RAII so it is released on every path
+        // below - including the parsing steps that operate on untrusted data and can throw before we are done
+        // with it - instead of being leaked. decompress() is reached repeatedly for corrupted blocks (fuzzing).
+        std::unique_ptr<uchar, void (*)(void *)> buffer_owner(buffer, &free);
+
         uchar const *bufferPos = buffer;
 
         decomposition.load(bufferPos, bufferSize);
@@ -87,7 +94,8 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
         auto quant_inds = encoder.decode(bufferPos, quant_inds_size);
         encoder.postprocess_decode();
 
-        free(buffer);
+        // The remaining work uses `quant_inds` and `decData` only, so release the internal buffer now.
+        buffer_owner.reset();
 
         decomposition.decompress(conf, quant_inds, decData);
         return decData;

--- a/include/SZ3/compressor/SZGenericCompressor.hpp
+++ b/include/SZ3/compressor/SZGenericCompressor.hpp
@@ -11,6 +11,7 @@
 #include "SZ3/utils/Config.hpp"
 #include "SZ3/utils/FileUtil.hpp"
 #include "SZ3/utils/Timer.hpp"
+#include "zstd.h"
 
 namespace SZ3 {
 /**
@@ -64,7 +65,15 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
 
     T *decompress(const Config &conf, uchar const *cmpData, size_t cmpSize, T *decData) override {
         uchar *buffer = nullptr;
-        size_t bufferSize = 0;
+        // The lossless layer reads the size of this internal buffer from the untrusted payload and would
+        // otherwise allocate it unbounded. Bound it by the largest internal buffer this configuration could
+        // have produced: during compression the buffer is losslessly (zstd) compressed, and
+        // ZSTD_compressBound(B) >= B, so a block that was actually stored with this compressor satisfies
+        // B < SZ_compress_size_bound = 4096 + conf.size_est() + ZSTD_compressBound(conf.num * sizeof(T)).
+        // Passing this as the capacity lets the lossless decoder reject a corrupted payload that declares a
+        // larger internal size before allocating it. conf.num is validated against the trusted output size by
+        // the caller, so this bound can not be inflated by corrupted input.
+        size_t bufferSize = 4096 + conf.size_est() + ZSTD_compressBound(conf.num * sizeof(T));
         lossless.decompress(cmpData, cmpSize, buffer, bufferSize);
 
         uchar const *bufferPos = buffer;

--- a/include/SZ3/compressor/SZGenericCompressor.hpp
+++ b/include/SZ3/compressor/SZGenericCompressor.hpp
@@ -52,10 +52,16 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
         uchar *buffer_pos = buffer;
 
         decomposition.save(buffer_pos);
-        encoder.save(buffer_pos);
 
-        //store the size of quant_inds is necessary as it is not always equal to conf.num
+        // Store the size of quant_inds; it is necessary as it is not always equal to conf.num.
+        // It is written BEFORE the encoder so that the encoder's serialized tree is immediately followed by
+        // its encoded stream, with no field in between. On decompression the encoder records how many bytes
+        // remain right after its tree and uses that as the bound for the encoded stream; a field written
+        // between the tree and the stream would make that bound too large and let a corrupted/truncated
+        // block read past the end of the buffer (see the matching order in decompress()).
         write<size_t>(quant_inds.size(), buffer_pos);
+
+        encoder.save(buffer_pos);
         encoder.encode(quant_inds, buffer_pos);
         encoder.postprocess_encode();
         
@@ -86,11 +92,15 @@ class SZGenericCompressor : public concepts::CompressorInterface<T> {
         uchar const *bufferPos = buffer;
 
         decomposition.load(bufferPos, bufferSize);
-        encoder.load(bufferPos, bufferSize);
 
         size_t quant_inds_size = 0;
         // Read the count with the bounded overload so a truncated buffer can not be read past its end.
         read(quant_inds_size, bufferPos, bufferSize);
+        // load() records the number of bytes remaining right after the encoder's serialized tree and uses it
+        // to bound the encoded stream during decode(). The quant_inds count above is read BEFORE this so that
+        // the tree is immediately followed by the encoded stream (matching the order in compress()); otherwise
+        // the recorded bound would include this field and a truncated block could read past the buffer.
+        encoder.load(bufferPos, bufferSize);
         auto quant_inds = encoder.decode(bufferPos, quant_inds_size);
         encoder.postprocess_decode();
 

--- a/include/SZ3/decomposition/InterpolationDecomposition.hpp
+++ b/include/SZ3/decomposition/InterpolationDecomposition.hpp
@@ -3,6 +3,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <stdexcept>
 
 #include "Decomposition.hpp"
 #include "SZ3/def.hpp"
@@ -24,6 +25,20 @@ class InterpolationDecomposition : public concepts::DecompositionInterface<T, in
     }
 
     T *decompress(const Config &conf, std::vector<int> &quant_inds, T *dec_data) override {
+        // `original_dimensions` was read from the (untrusted) compressed payload by `load`, separately from the
+        // trusted `conf.dims`. It drives the size of the grid walked over `dec_data` below (and the number of
+        // `quant_inds` consumed), so a tampered value larger than the trusted configuration would read and
+        // write past the end of both buffers, which are sized for `conf.num` elements (== product of conf.dims).
+        // Require it to match the trusted configuration dimensions before using it for anything.
+        if (conf.dims.size() != N) {
+            throw std::out_of_range("SZ3 interpolation: configuration dimension count does not match the data");
+        }
+        for (uint i = 0; i < N; i++) {
+            if (original_dimensions[i] != conf.dims[i]) {
+                throw std::out_of_range("SZ3 interpolation: stored dimensions do not match the trusted configuration");
+            }
+        }
+
         init();
 
         this->quant_inds = quant_inds.data();

--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -14,6 +14,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
 #include <map>
 #include <set>
 #include <unordered_set>
@@ -228,21 +229,34 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
         size_t i = 0, byteIndex = 0, count = 0;
         int r;
         node n = treeRoot;
+        /// Bytes available for the encoded payload, recorded by load(). Used to bound all reads below.
+        size_t remaining = decode_remaining_length;
+        if (remaining < sizeof(size_t))
+            throw std::out_of_range("SZ3 Huffman: truncated encoded length");
         size_t encodedLength = 0;
         read(encodedLength, bytes);
+        remaining -= sizeof(size_t);
         if (n->t)  // root->t==1 means that all state values are the same (constant)
         {
             for (count = 0; count < targetLength; count++) out[count] = n->c + offset;
             return out;
         }
 
+        if (encodedLength > remaining)
+            throw std::out_of_range("SZ3 Huffman: encoded length exceeds compressed buffer");
+
         for (i = 0; count < targetLength; i++) {
             byteIndex = i >> 3;  // i/8
+            if (byteIndex >= encodedLength)
+                throw std::out_of_range("SZ3 Huffman: corrupted encoded stream");
             r = i % 8;
             if (((bytes[byteIndex] >> (7 - r)) & 0x01) == 0)
                 n = n->left;
             else
                 n = n->right;
+
+            if (n == nullptr)
+                throw std::out_of_range("SZ3 Huffman: corrupted tree");
 
             if (n->t) {
                 out[count] = n->c + offset;
@@ -260,8 +274,14 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
     // load Huffman tree
     void load(const uchar *&c, size_t &remaining_length) override {
         read(offset, c, remaining_length);
+        if (remaining_length < 2 * sizeof(int))
+            throw std::out_of_range("SZ3 Huffman: truncated tree header");
         nodeCount = bytesToInt32_bigEndian(c);
         int stateNum = bytesToInt32_bigEndian(c + sizeof(int)) * 2;
+        /// `nodeCount` comes from untrusted data. Bound it before it is used in size computations so
+        /// the encodeStartIndex arithmetic below cannot overflow and the tree cannot be read past the buffer.
+        if (nodeCount <= 0 || static_cast<size_t>(nodeCount) > remaining_length)
+            throw std::out_of_range("SZ3 Huffman: invalid node count");
         size_t encodeStartIndex;
         if (nodeCount <= 256)
             encodeStartIndex = 1 + 3 * nodeCount * sizeof(unsigned char) + nodeCount * sizeof(T);
@@ -272,9 +292,15 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
             encodeStartIndex =
                 1 + 2 * nodeCount * sizeof(unsigned int) + nodeCount * sizeof(unsigned char) + nodeCount * sizeof(T);
 
+        size_t tree_bytes = sizeof(int) + sizeof(int) + encodeStartIndex;
+        if (tree_bytes > remaining_length)
+            throw std::out_of_range("SZ3 Huffman: tree exceeds compressed buffer");
+
         huffmanTree = createHuffmanTree(stateNum);
         treeRoot = reconstruct_HuffTree_from_bytes_anyStates(c + sizeof(int) + sizeof(int), nodeCount);
-        c += sizeof(int) + sizeof(int) + encodeStartIndex;
+        c += tree_bytes;
+        remaining_length -= tree_bytes;
+        decode_remaining_length = remaining_length;
         loaded = true;
     }
 
@@ -286,6 +312,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
     unsigned int nodeCount = 0;
     uchar sysEndianType;  // 0: little endian, 1: big endian
     bool loaded = false;
+    size_t decode_remaining_length = 0;
     T offset;
 
     node reconstruct_HuffTree_from_bytes_anyStates(const unsigned char *bytes, uint nodeCount) {

--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -296,6 +296,13 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
         if (tree_bytes > remaining_length)
             throw std::out_of_range("SZ3 Huffman: tree exceeds compressed buffer");
 
+        /// The node pool is sized from stateNum, but the tree is reconstructed from nodeCount nodes; both come
+        /// from untrusted data. createHuffmanTree allocates a pool of 2*allNodes = 4*stateNum nodes, and the
+        /// reconstruction creates at most nodeCount of them, so reject a stateNum that is non-positive or too
+        /// small to hold nodeCount nodes - otherwise new_node2 would write past the end of the pool.
+        if (stateNum <= 0 || static_cast<size_t>(nodeCount) > 4 * static_cast<size_t>(stateNum))
+            throw std::out_of_range("SZ3 Huffman: node count exceeds the tree pool capacity");
+
         huffmanTree = createHuffmanTree(stateNum);
         treeRoot = reconstruct_HuffTree_from_bytes_anyStates(c + sizeof(int) + sizeof(int), nodeCount);
         c += tree_bytes;
@@ -347,7 +354,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
             memcpy(t, bytes + 1 + 2 * nodeCount * sizeof(unsigned char) + nodeCount * sizeof(T),
                    nodeCount * sizeof(unsigned char));
             node root = this->new_node2(C[0], t[0]);
-            this->unpad_tree<uchar>(L, R, C, t, 0, root);
+            this->unpad_tree<uchar>(L, R, C, t, 0, root, nodeCount);
             free(L);
             free(R);
             free(C);
@@ -388,7 +395,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
                    nodeCount * sizeof(unsigned char));
 
             node root = this->new_node2(0, 0);
-            this->unpad_tree<unsigned short>(L, R, C, t, 0, root);
+            this->unpad_tree<unsigned short>(L, R, C, t, 0, root, nodeCount);
             free(L);
             free(R);
             free(C);
@@ -429,7 +436,7 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
                    nodeCount * sizeof(unsigned char));
 
             node root = this->new_node2(0, 0);
-            this->unpad_tree<unsigned int>(L, R, C, t, 0, root);
+            this->unpad_tree<unsigned int>(L, R, C, t, 0, root, nodeCount);
             free(L);
             free(R);
             free(C);
@@ -606,21 +613,28 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
     }
 
     template <class T1>
-    void unpad_tree(T1 *L, T1 *R, T *C, unsigned char *t, unsigned int i, node root) {
+    void unpad_tree(T1 *L, T1 *R, T *C, unsigned char *t, unsigned int i, node root, unsigned int nodeCount) {
         // root->c = C[i];
         if (root->t == 0) {
             T1 l, r;
             l = L[i];
             if (l != 0) {
+                // Child indices come from untrusted data. pad_tree always assigns a child a higher index than
+                // its parent, so a valid index satisfies i < l < nodeCount. Enforcing this prevents reading
+                // L/R/C/t out of bounds and prevents a cycle that would overflow the node pool.
+                if (l <= i || l >= nodeCount)
+                    throw std::out_of_range("SZ3 Huffman: invalid left child index in tree");
                 node lroot = new_node2(C[l], t[l]);
                 root->left = lroot;
-                unpad_tree(L, R, C, t, l, lroot);
+                unpad_tree(L, R, C, t, l, lroot, nodeCount);
             }
             r = R[i];
             if (r != 0) {
+                if (r <= i || r >= nodeCount)
+                    throw std::out_of_range("SZ3 Huffman: invalid right child index in tree");
                 node rroot = new_node2(C[r], t[r]);
                 root->right = rroot;
-                unpad_tree(L, R, C, t, r, rroot);
+                unpad_tree(L, R, C, t, r, rroot, nodeCount);
             }
         }
     }

--- a/include/SZ3/lossless/Lossless_zstd.hpp
+++ b/include/SZ3/lossless/Lossless_zstd.hpp
@@ -49,6 +49,14 @@ class Lossless_zstd : public concepts::LosslessInterface {
         const size_t dst_capacity = dstLen;
         read(dstLen, src);
         if (dst == nullptr) {
+            /// dst == nullptr means the caller asks us to allocate the output buffer, and its size is read
+            /// from the (untrusted) compressed payload. When the caller supplies a non-zero capacity it is an
+            /// upper bound on how large that allocation may be; reject a payload that declares a larger size
+            /// before allocating it, so corrupted data can not force an arbitrary (and untracked) allocation.
+            /// A zero capacity means the caller did not supply a bound (legacy behavior).
+            if (dst_capacity != 0 && dstLen > dst_capacity) {
+                throw std::out_of_range("SZ3 lossless: declared decompressed size exceeds the allowed capacity");
+            }
             dst = static_cast<uchar *>(malloc(dstLen));
             if (dst == nullptr) {
                 throw std::runtime_error("SZ3 lossless: can not allocate the decompression buffer");

--- a/include/SZ3/lossless/Lossless_zstd.hpp
+++ b/include/SZ3/lossless/Lossless_zstd.hpp
@@ -43,12 +43,18 @@ class Lossless_zstd : public concepts::LosslessInterface {
         if (srcLen < sizeof(dstLen)) {
             throw std::out_of_range("SZ3 lossless: compressed data is smaller than the size header");
         }
+        /// When the caller provides the destination buffer, the incoming dstLen is its capacity. The
+        /// decompressed size is read from the (untrusted) compressed data, so it must not exceed that
+        /// capacity, otherwise zstd would write past the end of the buffer.
+        const size_t dst_capacity = dstLen;
         read(dstLen, src);
         if (dst == nullptr) {
             dst = static_cast<uchar *>(malloc(dstLen));
             if (dst == nullptr) {
                 throw std::runtime_error("SZ3 lossless: can not allocate the decompression buffer");
             }
+        } else if (dstLen > dst_capacity) {
+            throw std::out_of_range("SZ3 lossless: decompressed size exceeds the destination buffer");
         }
         size_t res = ZSTD_decompress(dst, dstLen, src, srcLen - sizeof(dstLen));
         if (ZSTD_isError(res)) {

--- a/include/SZ3/lossless/Lossless_zstd.hpp
+++ b/include/SZ3/lossless/Lossless_zstd.hpp
@@ -37,11 +37,24 @@ class Lossless_zstd : public concepts::LosslessInterface {
     }
 
     size_t decompress(const uchar *src, const size_t srcLen, uchar *&dst, size_t &dstLen) override {
+        /// The compressed buffer starts with the decompressed size, followed by the zstd stream.
+        /// Validate the inputs so corrupted data can not read out of bounds, allocate an untrusted
+        /// amount, or pass a zstd error code back as a size.
+        if (srcLen < sizeof(dstLen)) {
+            throw std::out_of_range("SZ3 lossless: compressed data is smaller than the size header");
+        }
         read(dstLen, src);
         if (dst == nullptr) {
             dst = static_cast<uchar *>(malloc(dstLen));
+            if (dst == nullptr) {
+                throw std::runtime_error("SZ3 lossless: can not allocate the decompression buffer");
+            }
         }
-        return ZSTD_decompress(dst, dstLen, src, srcLen - sizeof(dstLen));
+        size_t res = ZSTD_decompress(dst, dstLen, src, srcLen - sizeof(dstLen));
+        if (ZSTD_isError(res)) {
+            throw std::runtime_error("SZ3 lossless: zstd decompression failed");
+        }
+        return res;
     }
 
    private:

--- a/include/SZ3/lossless/Lossless_zstd.hpp
+++ b/include/SZ3/lossless/Lossless_zstd.hpp
@@ -68,6 +68,12 @@ class Lossless_zstd : public concepts::LosslessInterface {
         if (ZSTD_isError(res)) {
             throw std::runtime_error("SZ3 lossless: zstd decompression failed");
         }
+        /// The declared size is read from the (untrusted) payload; require zstd to actually produce that many
+        /// bytes, so a frame that expands to fewer bytes can not leave the tail of the output buffer
+        /// uninitialized (which a caller would otherwise copy out as if it were decompressed data).
+        if (res != dstLen) {
+            throw std::out_of_range("SZ3 lossless: decompressed size does not match the declared size");
+        }
         return res;
     }
 

--- a/include/SZ3/lossless/Lossless_zstd.hpp
+++ b/include/SZ3/lossless/Lossless_zstd.hpp
@@ -48,7 +48,8 @@ class Lossless_zstd : public concepts::LosslessInterface {
         /// capacity, otherwise zstd would write past the end of the buffer.
         const size_t dst_capacity = dstLen;
         read(dstLen, src);
-        if (dst == nullptr) {
+        const bool self_allocated = (dst == nullptr);
+        if (self_allocated) {
             /// dst == nullptr means the caller asks us to allocate the output buffer, and its size is read
             /// from the (untrusted) compressed payload. When the caller supplies a non-zero capacity it is an
             /// upper bound on how large that allocation may be; reject a payload that declares a larger size
@@ -64,17 +65,27 @@ class Lossless_zstd : public concepts::LosslessInterface {
         } else if (dstLen > dst_capacity) {
             throw std::out_of_range("SZ3 lossless: decompressed size exceeds the destination buffer");
         }
-        size_t res = ZSTD_decompress(dst, dstLen, src, srcLen - sizeof(dstLen));
-        if (ZSTD_isError(res)) {
-            throw std::runtime_error("SZ3 lossless: zstd decompression failed");
+        try {
+            size_t res = ZSTD_decompress(dst, dstLen, src, srcLen - sizeof(dstLen));
+            if (ZSTD_isError(res)) {
+                throw std::runtime_error("SZ3 lossless: zstd decompression failed");
+            }
+            /// The declared size is read from the (untrusted) payload; require zstd to actually produce that
+            /// many bytes, so a frame that expands to fewer bytes can not leave the tail of the output buffer
+            /// uninitialized (which a caller would otherwise copy out as if it were decompressed data).
+            if (res != dstLen) {
+                throw std::out_of_range("SZ3 lossless: decompressed size does not match the declared size");
+            }
+            return res;
+        } catch (...) {
+            /// Free a buffer we allocated ourselves so a corrupted payload that fails decompression here does
+            /// not leak it; a caller-provided buffer is owned by the caller and is left untouched.
+            if (self_allocated) {
+                free(dst);
+                dst = nullptr;
+            }
+            throw;
         }
-        /// The declared size is read from the (untrusted) payload; require zstd to actually produce that many
-        /// bytes, so a frame that expands to fewer bytes can not leave the tail of the output buffer
-        /// uninitialized (which a caller would otherwise copy out as if it were decompressed data).
-        if (res != dstLen) {
-            throw std::out_of_range("SZ3 lossless: decompressed size does not match the declared size");
-        }
-        return res;
     }
 
    private:

--- a/include/SZ3/predictor/ComposedPredictor.hpp
+++ b/include/SZ3/predictor/ComposedPredictor.hpp
@@ -45,7 +45,13 @@ class ComposedPredictor : public concepts::PredictorInterface<T, N> {
     }
 
     bool predecompress(const block_iter &block) override {
+        // selection and its entries come from untrusted data; bound the running index into selection and the
+        // selected predictor index before using them. predict()/estimate_error() reuse the sid set here.
+        if (current_index >= selection.size())
+            throw std::out_of_range("SZ3: ran out of predictor selections while decompressing");
         sid = selection[current_index++];
+        if (sid < 0 || static_cast<size_t>(sid) >= predictors.size())
+            throw std::out_of_range("SZ3: predictor selection index is out of range");
         return predictors[sid]->predecompress(block);
     }
 

--- a/include/SZ3/predictor/LorenzoPredictor.hpp
+++ b/include/SZ3/predictor/LorenzoPredictor.hpp
@@ -97,7 +97,11 @@ class LorenzoPredictor : public concepts::PredictorInterface<T, N> {
     T noise = 0;
 
    private:
-    // Helper functions for Lorenzo prediction
+    // Helper functions for Lorenzo prediction.
+    // The neighbour offsets are unsigned, so `d[-offset]` is `*(d + (size_t)(-offset))`, which forms an
+    // out-of-bounds pointer by wrapping the unsigned addition (flagged by -fsanitize=pointer-overflow even
+    // though the accessed element is in bounds thanks to the predictor's padding). Compute the address with
+    // pointer subtraction instead, so the offset stays a small negative step and no wrap-around occurs.
     ALWAYS_INLINE T prev1(T *d, size_t i) { return *(d - i); }
     ALWAYS_INLINE T prev2(T *d, const std::array<size_t, N> &ds, size_t j, size_t i) { return *(d - (j * ds[0] + i)); }
     ALWAYS_INLINE T prev3(T *d, const std::array<size_t, N> &ds, size_t k, size_t j, size_t i) {

--- a/include/SZ3/predictor/RegressionPredictor.hpp
+++ b/include/SZ3/predictor/RegressionPredictor.hpp
@@ -155,6 +155,10 @@ class RegressionPredictor : public concepts::PredictorInterface<T, N> {
     }
 
     void pred_and_recover_coefficients() {
+        // Each block consumes N + 1 regression coefficients; the coefficient stream comes from untrusted data,
+        // so a crafted block count larger than the stored coefficients would read past its end.
+        if (regression_coeff_index + N + 1 > regression_coeff_quant_inds.size())
+            throw std::out_of_range("SZ3: ran out of regression coefficients while decompressing");
         for (int i = 0; i < static_cast<int>(N); i++) {
             current_coeffs[i] =
                 quantizer_liner.recover(current_coeffs[i], regression_coeff_quant_inds[regression_coeff_index++]);

--- a/include/SZ3/quantizer/LinearQuantizer.hpp
+++ b/include/SZ3/quantizer/LinearQuantizer.hpp
@@ -83,7 +83,13 @@ public:
         return pred + 2 * (quant_index - this->radius) * this->error_bound;
     }
 
-    ALWAYS_INLINE T recover_unpred() { return unpred[index++]; }
+    ALWAYS_INLINE T recover_unpred() {
+        // index and the quantization stream come from untrusted data; a crafted stream can request more
+        // unpredictable values than were stored, which would read past the end of unpred.
+        if (index >= unpred.size())
+            throw std::out_of_range("SZ3: ran out of unpredictable values while decompressing");
+        return unpred[index++];
+    }
 
     ALWAYS_INLINE int force_save_unpred(T ori) override {
         unpred.push_back(ori);
@@ -115,6 +121,10 @@ public:
         size_t unpred_size = 0;
         read(unpred_size, c, remaining_length);
         if (unpred_size > 0) {
+            // Validate the count against the remaining bytes before resizing, otherwise a corrupted count
+            // would drive a huge allocation before the bounded read below has a chance to reject it.
+            if (unpred_size > remaining_length / sizeof(T))
+                throw std::out_of_range("SZ3: unpredictable value count exceeds the compressed buffer");
             unpred.resize(unpred_size);
             read(unpred.data(), unpred_size, c, remaining_length);
         }

--- a/include/SZ3/utils/Config.hpp
+++ b/include/SZ3/utils/Config.hpp
@@ -15,8 +15,10 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <numeric>
+#include <stdexcept>
 #include <vector>
 
 #include "SZ3/def.hpp"
@@ -358,38 +360,87 @@ class Config {
      *
      * @param c Pointer to the byte array.
      */
-    void load(const unsigned char*& c) {
+    // Legacy overload for trusted internal callers (e.g. the OpenMP path).
+    void load(const unsigned char*& c) { load(c, std::numeric_limits<size_t>::max()); }
+
+    // `cmpSize` bounds how many bytes may be read from `c` (the config blob). Used when loading
+    // from untrusted compressed data so a corrupted config cannot read out of bounds.
+    void load(const unsigned char*& c, size_t cmpSize) {
+        const unsigned char* const c0 = c;
+        auto require = [&](size_t n)
+        {
+            if (cmpSize - static_cast<size_t>(c - c0) < n)
+                throw std::out_of_range("SZ3 Config::load: read past the end of the config");
+        };
+
+        require(sizeof(uchar));
         uchar confSize = 0;
         read(confSize, c);
-        auto c1 = c + confSize;
+        /// `confSize` is the total size of the config blob, including this prefix byte.
+        if (confSize > cmpSize)
+            throw std::out_of_range("SZ3 Config::load: config size exceeds the buffer");
+        auto c1 = c0 + confSize;
 
+        require(sizeof(N));
         read(N, c);
+        if (N < 1 || N > 4)
+            throw std::out_of_range("SZ3 Config::load: invalid number of dimensions");
         uint8_t bitWidth;
+        require(sizeof(bitWidth));
         read(bitWidth, c);
+        if (bitWidth > 64)
+            throw std::out_of_range("SZ3 Config::load: invalid dimension bit width");
+        require((static_cast<size_t>(N) * bitWidth + 7) / 8);
         dims = bytes2vector<size_t>(c, bitWidth, N);
-        // dims.resize(N);
-        // read(dims.data(), N, c);
+        require(sizeof(num));
         read(num, c);
+        /// The element count must equal the product of the dimensions, otherwise the predictor would
+        /// iterate over more grid positions than were allocated for the decompressed data. Validate
+        /// the product with an overflow check.
+        {
+            size_t dims_product = 1;
+            bool dims_ok = true;
+            for (size_t dim : dims)
+            {
+                if (dim == 0 || dims_product > std::numeric_limits<size_t>::max() / dim)
+                {
+                    dims_ok = false;
+                    break;
+                }
+                dims_product *= dim;
+            }
+            if (!dims_ok || dims_product != num)
+                throw std::out_of_range("SZ3 Config::load: dimensions inconsistent with the element count");
+        }
+        require(sizeof(cmprAlgo));
         read(cmprAlgo, c);
 
+        require(sizeof(errorBoundMode));
         read(errorBoundMode, c);
         if (errorBoundMode == EB_ABS) {
+            require(sizeof(absErrorBound));
             read(absErrorBound, c);
         } else if (errorBoundMode == EB_REL) {
+            require(sizeof(relErrorBound));
             read(relErrorBound, c);
         } else if (errorBoundMode == EB_PSNR) {
+            require(sizeof(psnrErrorBound));
             read(psnrErrorBound, c);
         } else if (errorBoundMode == EB_L2NORM) {
+            require(sizeof(l2normErrorBound));
             read(l2normErrorBound, c);
         } else if (errorBoundMode == EB_ABS_OR_REL) {
+            require(sizeof(absErrorBound) + sizeof(relErrorBound));
             read(absErrorBound, c);
             read(relErrorBound, c);
         } else if (errorBoundMode == EB_ABS_AND_REL) {
+            require(sizeof(absErrorBound) + sizeof(relErrorBound));
             read(absErrorBound, c);
             read(relErrorBound, c);
         }
 
         if (c < c1) {
+            require(sizeof(uint8_t));
             uint8_t boolvals;
             read(boolvals, c);
             lorenzo = (boolvals >> 7) & 1;
@@ -399,15 +450,19 @@ class Config {
             openmp = (boolvals >> 3) & 1;
         }
         if (c < c1) {
+            require(sizeof(dataType));
             read(dataType, c);
         }
         if (c < c1) {
+            require(sizeof(quantbinCnt));
             read(quantbinCnt, c);
         }
         if (c < c1) {
+            require(sizeof(blockSize));
             read(blockSize, c);
         }
         if (c < c1) {
+            require(sizeof(predDim));
             read(predDim, c);
         }
     }

--- a/include/SZ3/utils/MemoryUtil.hpp
+++ b/include/SZ3/utils/MemoryUtil.hpp
@@ -6,6 +6,7 @@
 #define SZ3_MEMORYOPS_HPP
 
 #include <cassert>
+#include <stdexcept>
 #include <cstring>
 #include <cstdint>
 
@@ -73,7 +74,8 @@ inline T byteswap(T value) {
 // read array
 template <class T1>
 void read(T1 *array, size_t num_elements, uchar const *&compressed_data_pos, size_t &remaining_length) {
-    assert(num_elements * sizeof(T1) <= remaining_length);
+    if (sizeof(T1) != 0 && num_elements > remaining_length / sizeof(T1))
+        throw std::out_of_range("SZ3: attempt to read past the end of the compressed buffer");
     memcpy(array, compressed_data_pos, num_elements * sizeof(T1));
     if constexpr (SZ3_BIG_ENDIAN) {
         for (size_t i = 0; i < num_elements; i++) {
@@ -109,7 +111,8 @@ void read(T1 &var, uchar const *&compressed_data_pos) {
 // read variable
 template <class T1>
 void read(T1 &var, uchar const *&compressed_data_pos, size_t &remaining_length) {
-    assert(sizeof(T1) <= remaining_length);
+    if (sizeof(T1) > remaining_length)
+        throw std::out_of_range("SZ3: attempt to read past the end of the compressed buffer");
     memcpy(&var, compressed_data_pos, sizeof(T1));
     if constexpr (SZ3_BIG_ENDIAN) {
         var = byteswap(var);


### PR DESCRIPTION
### Problem

The decompression path reads sizes, counts and dimensions from the compressed stream and uses them to drive reads and writes without validating them against the size of the input buffer. On corrupted or adversarial input (for example when fuzzing the decompressor) this leads to out-of-bounds reads and writes — a `decode()` loop bounded only by the target length, a Huffman tree reconstructed from an unvalidated node count, an unchecked payload-size field in `SZ_decompress`, etc.

### Changes

This adds bounds checks along the decompression path. Valid data is unaffected — the checks only fire on input that would otherwise read or write out of bounds.

- **`MemoryUtil`**: the length-checked `read()` overloads (the ones that take `remaining_length`) now throw `std::out_of_range` instead of `assert()`, which is a no-op in release builds.
- **`SZ_decompress`** (`sz.hpp`): validate that the buffer is at least the 16-byte header and that the stored compressed-payload size fits in the remaining buffer.
- **`Config::load`**: take the size of the config blob and bound every read against it; validate the dimension count (1..4) and per-dimension bit width before reading the dimensions; and check that the product of the dimensions equals the element count. (This also includes the end-pointer fix from #131.)
- **`HuffmanEncoder::load`/`decode`**: validate the node count, the serialized tree size and the encoded length against the available bytes, and guard against null nodes produced by a malformed tree.
- **`HuffmanEncoder` tree reconstruction**: `unpad_tree` now rejects child indices that are out of range (a valid tree always assigns a child a higher index than its parent, so `parent < child < nodeCount`), which prevents out-of-bounds reads of the `L`/`R`/`C`/`t` arrays and cycles; and a `stateNum` too small to hold `nodeCount` nodes is rejected so the node pool can not overflow.
- **`LinearQuantizer`**: `recover_unpred` bounds its index against the unpredictable-value vector, and `load` validates the unpredictable count against the remaining bytes before resizing.
- **`RegressionPredictor` / `ComposedPredictor`**: bound the per-block coefficient/selection indices against the decoded vectors, and validate the selected predictor id.
- **`Lossless_zstd::decompress` / `SZ_decompress_dispatcher`**: on the `ALGO_LOSSLESS` path the pre-allocated output buffer is now passed to the lossless decoder with its capacity, and a payload that declares a larger decompressed size is rejected before zstd writes — previously the size came from the payload and was used as the zstd destination capacity unchecked (a heap buffer overflow).
- **`SZGenericCompressor::decompress`**: read the quantization-index count with the bounded overload so a truncated buffer is not read past its end.
- **`SZ_decompress_OMP`** (the OpenMP decompression path): bound the thread-count read, parse each per-thread config with the bounded `Config::load`, bound the per-thread size array, and build the per-thread payload offsets with an overflow-safe bound so each thread's slice stays within the buffer.

- **Generic lossy path (`SZGenericCompressor::decompress`)**: the internal buffer size is read from the payload and was allocated unbounded for `ALGO_INTERP`/`ALGO_LORENZO_REG`. It is now bounded by the largest buffer the configuration could have produced (`4096 + conf.size_est() + ZSTD_compressBound(conf.num * sizeof(T))`, valid because `ZSTD_compressBound(B) >= B`), passed as a capacity that `Lossless_zstd::decompress` enforces before allocating.

- **`Lossless_zstd::decompress` fail-closed**: also require `ZSTD_decompress` to produce exactly the declared size, so a frame that expands to fewer bytes can not leave the tail of the (caller-provided) output buffer uninitialized.

- **Inner interpolation dimensions + RAII scratch buffer**: `InterpolationDecomposition::decompress` rejects a block whose separately-stored dimensions do not match the trusted config (otherwise it would iterate past the output buffer), and `SZGenericCompressor::decompress` owns its scratch buffer with RAII so a corrupted block can not leak it.

- **Pointer-overflow UB + Huffman over-read (sanitizer findings)**: `LorenzoPredictor` neighbour helpers computed `d[-offset]` with an unsigned offset (`*(d + (size_t)(-offset))`, a wrapped/out-of-bounds pointer flagged by `-fsanitize=pointer-overflow`) — now use pointer subtraction; and the `quant_inds` count is written before the encoder so its serialized tree is immediately followed by its stream, so the decode bound recorded by `load()` is no longer one field too large (which let a truncated block over-read).

### Notes

- `Config::load` gains a second overload `load(const unsigned char*&, size_t cmpSize)`; the existing one-argument overload is kept for internal/trusted callers and delegates with an unbounded size.
- This overlaps #131 in `Config::load` (it incorporates the same end-pointer fix). If #131 is merged first this rebases trivially.
- This does not change the value of any successfully-decompressed data; the new checks only reject inputs that are inconsistent with the buffer.

### Context

Found while integrating SZ3 as an experimental compression codec in ClickHouse and fuzzing the decompressor: https://github.com/ClickHouse/ClickHouse/pull/108788
