### PR TITLE
Fix undefined behavior in Huffman encoder for single-symbol input

### DIFF
--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -479,11 +479,14 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
         if (n->t) {
             huffmanTree->code[n->c] = static_cast<uint64_t *>(malloc(2 * sizeof(uint64_t)));
             if (len <= 64) {
-                (huffmanTree->code[n->c])[0] = out1 << (64 - len);
+                // A Huffman tree with a single symbol gives a zero-length code (build_code is called with
+                // len == 0 for the root). Shifting a 64-bit value by 64 is undefined behavior, so guard it.
+                (huffmanTree->code[n->c])[0] = (len == 0) ? 0 : (out1 << (64 - len));
                 (huffmanTree->code[n->c])[1] = out2;
             } else {
                 (huffmanTree->code[n->c])[0] = out1;
-                (huffmanTree->code[n->c])[1] = out2 << (128 - len);
+                // Likewise, len >= 128 would shift by >= 64; such codes do not fit in 128 bits anyway.
+                (huffmanTree->code[n->c])[1] = (len >= 128) ? out2 : (out2 << (128 - len));
             }
             huffmanTree->cout[n->c] = static_cast<unsigned char>(len);
             // std::cout << "build_code: c = " << n->c << ", len = " << len << ", out1 = " << out1 << ", out2 = " << out2


### PR DESCRIPTION
## Problem

`HuffmanEncoder::build_code` is invoked with `len == 0` for the tree root (see the `build_code(huffmanTree->qq[1], 0, 0, 0)` call). When the Huffman tree has a single symbol — which happens for constant input data, where every value maps to the same quantization code — the leaf *is* the root, so the code length is zero and the encoder executes:

```cpp
(huffmanTree->code[n->c])[0] = out1 << (64 - len);  // out1 << 64 when len == 0
```

Shifting a 64-bit value by 64 bits is undefined behavior in C++. It aborts under UndefinedBehaviorSanitizer (`shift exponent 64 is too large for 64-bit type`) and is generally unsafe.

## Fix

Handle `len == 0` explicitly (a zero-length code is empty, store 0). Also add a symmetric guard for `len >= 128` in the other branch, where `out2 << (128 - len)` would shift by `>= 64` (such codes do not fit in 128 bits anyway).

## Context

This was found while integrating SZ3 into ClickHouse, where compressing a column of constant floating-point values reliably triggered the crash on a UBSan build: https://github.com/ClickHouse/ClickHouse/pull/108788