### PR TITLE
Bounds-check HuffmanEncoderV2 tree loading against corrupted input

### DIFF
--- a/include/SZ3/encoder/HuffmanEncoderV2.hpp
+++ b/include/SZ3/encoder/HuffmanEncoderV2.hpp
@@ -1037,6 +1037,14 @@ private:
     void loadAsDFSOrder(const uchar*& bytes, size_t& remaining_length) {
         tree.init();
 
+        // The serialized tree is a fixed-size header followed by a DFS bitstream, and must fit in
+        // remaining_length. Bound every read so corrupted input can not read past the end of the buffer or
+        // allocate an untrusted amount.
+        const uchar* const tree_start = bytes;
+        const size_t header_size = 1 + sizeof(T) + 2 * sizeof(size_t);
+        if (remaining_length < header_size)
+            throw std::out_of_range("SZ3 HuffmanEncoderV2: truncated tree header");
+
         tree.usemp = (*bytes) >> 7;
         tree.mbft = (*bytes) & 0x3f;
         ++bytes;
@@ -1048,17 +1056,26 @@ private:
 
         tree.n = bytesToInt64_bigEndian(bytes);
         bytes += sizeof(size_t);
-        tree.ht.reserve(tree.n << 1);
 
-        
         tree.maxval = bytesToInt64_bigEndian(bytes);
         bytes += sizeof(size_t);
+
+        // The DFS bitstream follows the header; each of the tree.n nodes consumes at least one bit, so the
+        // node count can not exceed the available bits. This also avoids the tree.n << 1 overflow below.
+        const size_t dfs_bytes = remaining_length - header_size;
+        if (tree.n > dfs_bytes * 8)
+            throw std::out_of_range("SZ3 HuffmanEncoderV2: node count exceeds the compressed buffer");
+        tree.ht.reserve(tree.n << 1);
+
         if (tree.usemp == 0x00) {
             if (tree.n > 0) {
                 tree.veccode.resize(tree.maxval);
                 tree.veclen.resize(tree.maxval);
             }
         }
+
+        // The fixed-size header has now been consumed on every path below.
+        remaining_length -= header_size;
 
         if (tree.n == 0) {
             tree.setConstructed();
@@ -1090,6 +1107,8 @@ private:
         while (!stk.empty()) {
             Node* u = stk.top();
 
+            if (static_cast<size_t>(i >> 3) >= dfs_bytes)
+                throw std::out_of_range("SZ3 HuffmanEncoderV2: tree bitstream exceeds the compressed buffer");
             if (readBit(bytes, i++) == 0x00) {
                 tree.ht.push_back(Node());
                 if (u->p[0] == nullptr) {
@@ -1100,7 +1119,11 @@ private:
                 stk.push(&tree.ht[tree.ht.size() - 1]);
             } else {
                 T c = 0;
-                for (int j = 0; j < tree.mbft; j++) c |= static_cast<T>(readBit(bytes, i++)) << j;
+                for (int j = 0; j < tree.mbft; j++) {
+                    if (static_cast<size_t>(i >> 3) >= dfs_bytes)
+                        throw std::out_of_range("SZ3 HuffmanEncoderV2: tree bitstream exceeds the compressed buffer");
+                    c |= static_cast<T>(readBit(bytes, i++)) << j;
+                }
                 tree.ht.push_back(Node(c));
                 if (u->p[0] == nullptr)
                     u->p[0] = &tree.ht[tree.ht.size() - 1];
@@ -1118,6 +1141,10 @@ private:
         }
 
         bytes += (i + 7) >> 3;
+
+        // Consume the DFS bitstream from the caller's remaining length (the header was already subtracted
+        // above; the original code advanced the pointer but never decremented remaining_length).
+        remaining_length -= static_cast<size_t>(bytes - tree_start) - header_size;
 
         if (tree.usemp) {
             tree.dfs_mp(&tree.ht[tree.root]);


### PR DESCRIPTION
### Problem

`HuffmanEncoderV2::loadAsDFSOrder` reconstructs the Huffman tree from the compressed data without validating any of it against the available bytes. The `remaining_length` parameter is accepted but never used. On corrupted or adversarial input (e.g. when fuzzing the decompressor) this leads to:

- reading the fixed-size tree header past the end of the buffer;
- `tree.ht.reserve(tree.n << 1)` with an untrusted `tree.n` — an unbounded allocation, and `tree.n << 1` can overflow;
- the DFS reconstruction loop calling `readBit(bytes, i++)` with no upper bound on `i`, reading past the end of the buffer.

### Changes

Bounds checks only; valid data is unaffected (the checks fire only on input that would otherwise read out of bounds or allocate an untrusted amount):

- require the fixed-size header (`usemp`/`mbft`, `offset`, `n`, `maxval`) to fit in `remaining_length`;
- reject a node count larger than the available bits — each node consumes at least one bit of the DFS bitstream — which also avoids the `tree.n << 1` overflow in `reserve`;
- bound the DFS bit index against the available bytes; and
- decrement `remaining_length` by the bytes actually consumed (the original code advanced the pointer but never updated the length).

### Notes

This hardens the `load` path (which has a length). `decode()` does not currently receive a buffer length, so fully bounding its bit-reading loops would require threading a length through the `EncoderInterface::decode` signature; that is left out of this change.

### Context

Found while integrating SZ3 as an experimental compression codec in ClickHouse and fuzzing the decompressor: https://github.com/ClickHouse/ClickHouse/pull/108788