### PR TITLE
Bounds-check XtcBasedEncoder and Lossless_bypass against corrupted input

### DIFF
--- a/include/SZ3/encoder/XtcBasedEncoder.hpp
+++ b/include/SZ3/encoder/XtcBasedEncoder.hpp
@@ -9,6 +9,7 @@
 #define _SZ_XTC3_ENCODER_HPP
 
 #include <climits>
+#include <stdexcept>
 #include <vector>
 
 #include "SZ3/def.hpp"
@@ -597,10 +598,9 @@ class XtcBasedEncoder : public concepts::EncoderInterface<T> {
 
         size_t bufferSize = targetLength * 1.2;
         struct DataBuffer buffer;
-        buffer.data = reinterpret_cast<unsigned char *>(malloc(bufferSize * sizeof(int)));
-        if (buffer.data == nullptr) {
-            fprintf(stderr, "malloc failed\n");
-        }
+        // buffer.data is allocated below (after size3 is known); the previous allocation here was overwritten
+        // and leaked.
+        buffer.data = nullptr;
         buffer.index = 0;
         buffer.lastbits = 0;
         buffer.lastbyte = 0;
@@ -637,6 +637,9 @@ class XtcBasedEncoder : public concepts::EncoderInterface<T> {
         }
 
         int smallIdx = *inputIntPtr++;
+        // smallIdx is read from the compressed data and indexes the fixed-size magicInts table below.
+        if (smallIdx < 0 || smallIdx >= LASTIDX)
+            throw std::out_of_range("SZ3 Xtc: small index out of range");
 
         int smaller = magicInts[std::max(FIRSTIDX, smallIdx - 1)] / 2;
         int smallNum = magicInts[smallIdx] / 2;
@@ -648,8 +651,16 @@ class XtcBasedEncoder : public concepts::EncoderInterface<T> {
         size_t size3 = targetLength;
         bufferSize = size3 * 1.2;
         buffer.data = reinterpret_cast<unsigned char *>(malloc(bufferSize * sizeof(int)));
+        if (buffer.data == nullptr) {
+            throw std::runtime_error("SZ3 Xtc: can not allocate the decompression buffer");
+        }
         buffer.index = *(reinterpret_cast<const uint64_t *>(inputIntPtr));
         inputIntPtr += sizeof(uint64_t) / sizeof(int);
+
+        // buffer.index is an attacker-controlled byte count that is copied into buffer.data below; it must not
+        // exceed the buffer capacity, otherwise the memcpy loop overflows the heap buffer.
+        if (buffer.index > bufferSize * sizeof(int))
+            throw std::out_of_range("SZ3 Xtc: packed data size exceeds the decompression buffer");
 
         size_t offset = 0;
         size_t remain = buffer.index;
@@ -670,6 +681,9 @@ class XtcBasedEncoder : public concepts::EncoderInterface<T> {
         int run = 0;
         size_t i = 0;
         int *intBufferPoiner = reinterpret_cast<int *>(malloc(size3 * sizeof(*intBufferPoiner)));
+        if (intBufferPoiner == nullptr) {
+            throw std::runtime_error("SZ3 Xtc: can not allocate the index buffer");
+        }
         int *localIntBufferPointer = intBufferPoiner;
         unsigned char *charOutputPtr = reinterpret_cast<unsigned char *>(quantData.data());
         int *intOutputPtr = reinterpret_cast<int *>(charOutputPtr);

--- a/include/SZ3/lossless/Lossless_bypass.hpp
+++ b/include/SZ3/lossless/Lossless_bypass.hpp
@@ -6,6 +6,7 @@
 #define SZ3_LOSSLESS_BYPASS_HPP
 
 #include <cstring>
+#include <stdexcept>
 #include "SZ3/def.hpp"
 #include "SZ3/lossless/Lossless.hpp"
 
@@ -22,6 +23,9 @@ public:
         dstLen = srcLen;
         if (dst == nullptr) {
             dst = static_cast<uchar *>(malloc(dstLen));
+            if (dst == nullptr) {
+                throw std::runtime_error("SZ3 bypass lossless: can not allocate the decompression buffer");
+            }
         }
         std::memcpy(dst, src, dstLen);
         return dstLen;


### PR DESCRIPTION
### Problem

`XtcBasedEncoder::decode` and `Lossless_bypass::decompress` read sizes and indices from the compressed data without validating them. On corrupted or adversarial input (e.g. when fuzzing the decompressor) this leads to out-of-bounds writes/reads and a memory leak:

- `XtcBasedEncoder::decode` allocates `buffer.data` twice — the first allocation is immediately overwritten and leaked.
- `smallIdx`, read from the compressed data, indexes the fixed-size `magicInts` table (`magicInts[smallIdx]`, `magicInts[smallIdx - 1]`) with no range check — an out-of-bounds read of a static array.
- `buffer.index`, an attacker-controlled byte count read from the data, is `memcpy`'d into `buffer.data` without checking it against the buffer capacity — a heap buffer overflow.
- The `buffer.data` / index-buffer allocations are not null-checked.
- `Lossless_bypass::decompress` does not null-check its `malloc` before `memcpy`.

### Changes

Bounds checks and null checks only; valid data is unaffected:

- drop the leaked first `buffer.data` allocation;
- reject `smallIdx` outside `[0, LASTIDX)` before indexing `magicInts`;
- reject a packed size (`buffer.index`) larger than the `buffer.data` capacity before the copy loop;
- null-check the `buffer.data` and index-buffer allocations;
- null-check the `Lossless_bypass` allocation.

### Notes

`XtcBasedEncoder::decode` does not receive a length for its input buffer, so the reads from the input pointer itself can not be fully bounded without threading a length through the `EncoderInterface::decode` signature; this change bounds the out-of-bounds **writes** and the static-array index, which are the memory-corruption issues.

### Context

Found while integrating SZ3 as an experimental compression codec in ClickHouse and fuzzing the decompressor: https://github.com/ClickHouse/ClickHouse/pull/108788