### PR TITLE
Fix remaining_length accounting after Huffman decode in RegressionPredictor / ComposedPredictor

### DIFF
--- a/include/SZ3/predictor/ComposedPredictor.hpp
+++ b/include/SZ3/predictor/ComposedPredictor.hpp
@@ -72,8 +72,12 @@ class ComposedPredictor : public concepts::PredictorInterface<T, N> {
         if (selection_size > 0) {
             HuffmanEncoder<int> selection_encoder;
             selection_encoder.load(c, remaining_length);
+            /// decode() advances `c` past the encoded stream but does not update `remaining_length`;
+            /// account for exactly the bytes it consumed so the bound stays tight for later reads.
+            const uchar *decode_start = c;
             this->selection = selection_encoder.decode(c, selection_size);
             selection_encoder.postprocess_decode();
+            remaining_length -= static_cast<size_t>(c - decode_start);
         }
     }
 

--- a/include/SZ3/predictor/RegressionPredictor.hpp
+++ b/include/SZ3/predictor/RegressionPredictor.hpp
@@ -114,9 +114,14 @@ class RegressionPredictor : public concepts::PredictorInterface<T, N> {
             quantizer_liner.load(c, remaining_length);
             HuffmanEncoder<int> encoder = HuffmanEncoder<int>();
             encoder.load(c, remaining_length);
+            /// decode() advances `c` past the encoded stream but does not update `remaining_length`;
+            /// account for exactly the bytes it consumed. The previous `coeff_size * sizeof(int)` used the
+            /// uncompressed index count, which overshoots the (Huffman-compressed) stream and understates
+            /// remaining_length, making a later encoder.load() bound check spuriously reject valid data.
+            const uchar *decode_start = c;
             regression_coeff_quant_inds = encoder.decode(c, coeff_size);
             encoder.postprocess_decode();
-            remaining_length -= coeff_size * sizeof(int);
+            remaining_length -= static_cast<size_t>(c - decode_start);
             std::fill(current_coeffs.begin(), current_coeffs.end(), 0);
             regression_coeff_index = 0;
         }


### PR DESCRIPTION
## Problem

`RegressionPredictor::load` threads a `remaining_length` byte counter through its sub-reads so later reads know how many bytes are left. After Huffman-decoding the regression coefficients it does:

```cpp
encoder.load(c, remaining_length);
regression_coeff_quant_inds = encoder.decode(c, coeff_size);
encoder.postprocess_decode();
remaining_length -= coeff_size * sizeof(int);   // <-- wrong amount
```

`decode` advances the read pointer `c` by the *compressed* (Huffman) stream size, but `remaining_length` is decremented by `coeff_size * sizeof(int)` — the *uncompressed* index count. Those two are unrelated, so after this point `remaining_length` no longer reflects the bytes actually consumed (it typically overshoots the compressed stream and understates the remainder, and can even wrap past zero).

`ComposedPredictor::load` has the mirror defect: it Huffman-decodes a per-block predictor-selection stream but never decrements `remaining_length` for it at all.

Today the `read` helpers in `MemoryUtil.hpp` only guard the counter with `assert`, so a release build tolerates the wrong value and the bug is latent. But any reader that actually enforces the bound will then reject valid data. This surfaced while integrating SZ3 into ClickHouse, whose hardened build makes those reads throw instead of `assert`: a column compressed with `ALGO_LORENZO_REG` could be written but failed every subsequent read.

## Fix

Decrement `remaining_length` by exactly the bytes `decode` consumed, measured as the pointer advance:

```cpp
const uchar *decode_start = c;
regression_coeff_quant_inds = encoder.decode(c, coeff_size);
encoder.postprocess_decode();
remaining_length -= static_cast<size_t>(c - decode_start);
```

and apply the same accounting to the selection stream in `ComposedPredictor::load`. Behavior for valid data is unchanged; the counter now tracks the real byte cursor.

## Context

Found while integrating SZ3 into ClickHouse. Companion fix on the ClickHouse fork: https://github.com/ClickHouse/SZ3/pull/2
