### PR TITLE
Fix undefined behavior casting non-finite / out-of-range float to int in LinearQuantizer

### DIFF
--- a/include/SZ3/quantizer/LinearQuantizer.hpp
+++ b/include/SZ3/quantizer/LinearQuantizer.hpp
@@ -42,32 +42,35 @@ public:
     // int quantize(T data, T pred, T& dec_data);
     ALWAYS_INLINE int quantize_and_overwrite(T& data, T pred) override {
         T diff = data - pred;
-        auto quant_index = static_cast<int64_t>(fabs(diff) * this->error_bound_reciprocal) + 1;
-        if (quant_index < this->radius * 2) {
-            quant_index >>= 1;
-            int half_index = quant_index;
-            quant_index <<= 1;
-            int quant_index_shifted;
-            if (diff < 0) {
-                quant_index = -quant_index;
-                quant_index_shifted = this->radius - half_index;
-            } else {
-                quant_index_shifted = this->radius + half_index;
+        // fabs(diff) * error_bound_reciprocal is NaN when data is NaN and exceeds the int64_t
+        // range for infinities or huge magnitudes; casting those to int64_t is undefined behaviour.
+        // Only finite magnitudes within the quantization range are representable as an index; every
+        // other value is stored losslessly in unpred, exactly like the out-of-range branch below.
+        double scaled = fabs(diff) * this->error_bound_reciprocal;
+        if (scaled < this->radius * 2) {
+            auto quant_index = static_cast<int64_t>(scaled) + 1;
+            if (quant_index < this->radius * 2) {
+                quant_index >>= 1;
+                int half_index = quant_index;
+                quant_index <<= 1;
+                int quant_index_shifted;
+                if (diff < 0) {
+                    quant_index = -quant_index;
+                    quant_index_shifted = this->radius - half_index;
+                } else {
+                    quant_index_shifted = this->radius + half_index;
+                }
+                T decompressed_data = pred + quant_index * this->error_bound;
+                // if data is NaN, the diff is NaN, and NaN <= 0 is false
+                diff = fabs(decompressed_data - data);
+                if (diff <= this->error_bound || (!strict_eb && diff <= this->error_bound * 1.1)) {
+                    data = decompressed_data;
+                    return quant_index_shifted;
+                }
             }
-            T decompressed_data = pred + quant_index * this->error_bound;
-            // if data is NaN, the diff is NaN, and NaN <= 0 is false
-            diff = fabs(decompressed_data - data);
-            if (diff <= this->error_bound || (!strict_eb && diff <= this->error_bound * 1.1)) {
-                data = decompressed_data;
-                return quant_index_shifted;
-            } else {
-                unpred.push_back(data);
-                return 0;
-            }
-        } else {
-            unpred.push_back(data);
-            return 0;
         }
+        unpred.push_back(data);
+        return 0;
     }
 
     // recover the data using the quantization index


### PR DESCRIPTION
## Problem

`LinearQuantizer::quantize_and_overwrite` computes a quantization index by casting a floating-point product to `int64_t`:

```cpp
T diff = data - pred;
auto quant_index = static_cast<int64_t>(fabs(diff) * this->error_bound_reciprocal) + 1;
```

When the input `data` is `NaN`, `diff` is `NaN`; for infinities or very large magnitudes the product exceeds the `int64_t` range. Converting such a value to an integer is undefined behavior in C++. It is reported by UndefinedBehaviorSanitizer under `float-cast-overflow` as `... is outside the range of representable values of type 'long'`, and yields a garbage index on any platform.

## Fix

Compute the scaled magnitude as a `double` and check that it is within the representable quantization range *before* the cast. `NaN` fails the `scaled < radius * 2` comparison (any comparison with `NaN` is false) and infinities/overflows fail it too, so every non-representable value falls through to be stored losslessly in `unpred` — exactly the same outcome the existing out-of-range branch already produced for finite values. Quantization of representable values is unchanged.

## Context

Found while integrating SZ3 into ClickHouse (UBSan build, compressing float columns that contain `NaN`/`Inf`). Companion fix on the ClickHouse fork: https://github.com/ClickHouse/SZ3/pull/3
