### PR TITLE
Drop 31 no-op ALWAYS_INLINE keywords + fix SDRBench dataset URLs

### DIFF
--- a/include/SZ3/predictor/ComposedPredictor.hpp
+++ b/include/SZ3/predictor/ComposedPredictor.hpp
@@ -77,11 +77,11 @@ class ComposedPredictor : public concepts::PredictorInterface<T, N> {
         }
     }
 
-    ALWAYS_INLINE T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         return predictors[sid]->predict(block, d, index);
     }
 
-    ALWAYS_INLINE T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         return predictors[sid]->estimate_error(block, d, index);
     }
 

--- a/include/SZ3/predictor/LorenzoPredictor.hpp
+++ b/include/SZ3/predictor/LorenzoPredictor.hpp
@@ -53,11 +53,11 @@ class LorenzoPredictor : public concepts::PredictorInterface<T, N> {
 
     size_t get_padding() override { return 2; }
 
-    ALWAYS_INLINE T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         return fabs(*d - predict(block, d, index)) + this->noise;
     }
 
-    ALWAYS_INLINE T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         auto ds = block.get_dim_strides();
         if constexpr (N == 1 && L == 1) {
             return prev1(d, 1);
@@ -98,12 +98,12 @@ class LorenzoPredictor : public concepts::PredictorInterface<T, N> {
 
    private:
     // Helper functions for Lorenzo prediction
-    ALWAYS_INLINE T prev1(T *d, size_t i) { return *(d - i); }
-    ALWAYS_INLINE T prev2(T *d, const std::array<size_t, N> &ds, size_t j, size_t i) { return *(d - (j * ds[0] + i)); }
-    ALWAYS_INLINE T prev3(T *d, const std::array<size_t, N> &ds, size_t k, size_t j, size_t i) {
+    T prev1(T *d, size_t i) { return *(d - i); }
+    T prev2(T *d, const std::array<size_t, N> &ds, size_t j, size_t i) { return *(d - (j * ds[0] + i)); }
+    T prev3(T *d, const std::array<size_t, N> &ds, size_t k, size_t j, size_t i) {
         return *(d - (k * ds[1] + j * ds[0] + i));
     }
-    ALWAYS_INLINE T prev4(T *d, const std::array<size_t, N> &ds, size_t t, size_t k, size_t j, size_t i) {
+    T prev4(T *d, const std::array<size_t, N> &ds, size_t t, size_t k, size_t j, size_t i) {
         return *(d - (t * ds[2] + k * ds[1] + j * ds[0] + i));
     }
 };

--- a/include/SZ3/predictor/Predictor.hpp
+++ b/include/SZ3/predictor/Predictor.hpp
@@ -28,14 +28,14 @@ class PredictorInterface {
      * @param std::array<size_t, N> the relative index of the data point in the block
      * @return the predicted value
      */
-    ALWAYS_INLINE virtual T predict(const block_iter &, T *, const std::array<size_t, N> &) = 0;
+    virtual T predict(const block_iter &, T *, const std::array<size_t, N> &) = 0;
 
     /**
      * estimate the prediction error ( |prediction value - read value|)  for a single data point
      * @param iter the iterator of the single data point
      * @return the estimated prediction error
      */
-    ALWAYS_INLINE virtual T estimate_error(const block_iter &, T *, const std::array<size_t, N> &) = 0;
+    virtual T estimate_error(const block_iter &, T *, const std::array<size_t, N> &) = 0;
 
     /**
      * compute auxiliary info (e.g., coefficients) for the given data block

--- a/include/SZ3/predictor/RegressionPredictor.hpp
+++ b/include/SZ3/predictor/RegressionPredictor.hpp
@@ -70,11 +70,11 @@ class RegressionPredictor : public concepts::PredictorInterface<T, N> {
         return true;
     }
 
-    ALWAYS_INLINE T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T estimate_error(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         return fabs(*d - predict(block, d, index));
     }
 
-    ALWAYS_INLINE T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
+    T predict(const block_iter &block, T *d, const std::array<size_t, N> &index) override {
         if constexpr (N == 1) {
             return current_coeffs[0] * index[0] + current_coeffs[1];
         } else if constexpr (N == 2) {

--- a/include/SZ3/quantizer/Quantizer.hpp
+++ b/include/SZ3/quantizer/Quantizer.hpp
@@ -22,7 +22,7 @@ class   QuantizerInterface {
      * @param pred predicted value for this data point
      * @return quantized error
      */
-    ALWAYS_INLINE virtual To quantize_and_overwrite(Ti &data, Ti pred) = 0;
+    virtual To quantize_and_overwrite(Ti &data, Ti pred) = 0;
 
     /**
      * reconstructed the data point
@@ -30,7 +30,7 @@ class   QuantizerInterface {
      * @param quant_index quantized error
      * @return reconstructed value of the data point
      */
-    ALWAYS_INLINE virtual Ti recover(Ti pred, To quant_index) = 0;
+    virtual Ti recover(Ti pred, To quant_index) = 0;
 
     virtual To force_save_unpred(Ti ori) = 0;
 

--- a/include/SZ3/utils/Config.hpp
+++ b/include/SZ3/utils/Config.hpp
@@ -104,7 +104,7 @@ ALWAYS_INLINE std::string to_lower(const std::string& s) {
 }
 
 template <typename EnumType>
-ALWAYS_INLINE void match_enum(const std::string& input, const std::map<std::string, EnumType>& table, uint8_t& out) {
+void match_enum(const std::string& input, const std::map<std::string, EnumType>& table, uint8_t& out) {
     std::string input_lc = to_lower(input);
     for (const auto& [key, val] : table) {
         if (to_lower(key) == input_lc) {
@@ -114,7 +114,7 @@ ALWAYS_INLINE void match_enum(const std::string& input, const std::map<std::stri
 }
 
 template <typename EnumType>
-ALWAYS_INLINE std::string enum_to_string(EnumType value, const std::map<std::string, EnumType>& forward_map) {
+std::string enum_to_string(EnumType value, const std::map<std::string, EnumType>& forward_map) {
     for (const auto& [str, val] : forward_map) {
         if (val == value) {
             return str;

--- a/include/SZ3/utils/Interpolators.hpp
+++ b/include/SZ3/utils/Interpolators.hpp
@@ -9,52 +9,52 @@
 
 namespace SZ3 {
 template <class T>
-ALWAYS_INLINE T interp_linear(T a, T b) {
+T interp_linear(T a, T b) {
     return (a + b) / 2;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_linear1(T a, T b) {
+T interp_linear1(T a, T b) {
     return -0.5 * a + 1.5 * b;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_quad_1(T a, T b, T c) {
+T interp_quad_1(T a, T b, T c) {
     return (3 * a + 6 * b - c) / 8;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_quad_2(T a, T b, T c) {
+T interp_quad_2(T a, T b, T c) {
     return (-a + 6 * b + 3 * c) / 8;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_quad_3(T a, T b, T c) {
+T interp_quad_3(T a, T b, T c) {
     return (3 * a - 10 * b + 15 * c) / 8;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic(T a, T b, T c, T d) {
+T interp_cubic(T a, T b, T c, T d) {
     return (-a + 9 * b + 9 * c - d) / 16;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic_natural(T a, T b, T c, T d) {
+T interp_cubic_natural(T a, T b, T c, T d) {
    return 0.575 * (b + c) - 0.075 * (a + d);
 }
 
 template<class T>
-ALWAYS_INLINE T lorenzo_1d(T a, T b) {
+T lorenzo_1d(T a, T b) {
     return 2 * b - a;
 }
 
 template<class T>
-ALWAYS_INLINE T lorenzo_2d(T a, T b, T c) {
+T lorenzo_2d(T a, T b, T c) {
     return (b + c - a);
 }
 
 template<class T>
-ALWAYS_INLINE T lorenzo_3d(T a, T b, T c, T d, T e,T f,T g) {
+T lorenzo_3d(T a, T b, T c, T d, T e,T f,T g) {
     return (a - b - c + d - e + f + g);
 }
 
@@ -62,27 +62,27 @@ ALWAYS_INLINE T lorenzo_3d(T a, T b, T c, T d, T e,T f,T g) {
 
 
 template <class T>
-ALWAYS_INLINE T interp_cubic_front(T a, T b, T c, T d) {
+T interp_cubic_front(T a, T b, T c, T d) {
     return (5 * a + 15 * b - 5 * c + d) / 16;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic_front_2(T a, T b, T c, T d) {
+T interp_cubic_front_2(T a, T b, T c, T d) {
     return (a + 6 * b - 4 * c + d) / 4;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic_back_1(T a, T b, T c, T d) {
+T interp_cubic_back_1(T a, T b, T c, T d) {
     return (a - 5 * b + 15 * c + 5 * d) / 16;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic_back_2(T a, T b, T c, T d) {
+T interp_cubic_back_2(T a, T b, T c, T d) {
     return (-5 * a + 21 * b - 35 * c + 35 * d) / 16;
 }
 
 template <class T>
-ALWAYS_INLINE T interp_cubic2(T a, T b, T c, T d) {
+T interp_cubic2(T a, T b, T c, T d) {
     return (-3 * a + 23 * b + 23 * c - 3 * d) / 40;
 }
 

--- a/tools/test/integration/datasets.json
+++ b/tools/test/integration/datasets.json
@@ -1,6 +1,6 @@
 {
   "exaalt-small": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/EXAALT/SDRBENCH-EXAALT-2869440.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/EXAALT/SDRBENCH-EXAALT-2869440.tar.gz",
     "fields": {
       "xx.dat2": {"dims": [2869440], "dtype": "float32"},
       "yy.dat2": {"dims": [2869440], "dtype": "float32"},
@@ -11,7 +11,7 @@
     }
   }, 
   "hurricane": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/Hurricane-ISABEL/SDRBENCH-Hurricane-ISABEL-100x500x500.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/Hurricane-ISABEL/SDRBENCH-Hurricane-ISABEL-100x500x500.tar.gz",
     "fields": {
       "QCLOUDf48.bin.f32": {"dims": [100,500,500], "dtype": "float32"},
       "Wf48.bin.f32": {"dims": [100,500,500], "dtype": "float32"},
@@ -30,7 +30,7 @@
     }
   },
   "miranda": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/Miranda/SDRBENCH-Miranda-256x384x384.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/Miranda/SDRBENCH-Miranda-256x384x384.tar.gz",
     "fields": {
       "velocityx.d64": {"dims": [256,384,384], "dtype": "float64"},
       "velocityy.d64": {"dims": [256,384,384], "dtype": "float64"},
@@ -42,7 +42,7 @@
     }
   },
   "cesm-atm": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/CESM-ATM/SDRBENCH-CESM-ATM-1800x3600.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/CESM-ATM/SDRBENCH-CESM-ATM-1800x3600.tar.gz",
     "fields": {
       "CLDMED_1_1800_3600.f32": {"dims": [1800,3600], "dtype": "float32"},
       "ODV_bcar1_1_1800_3600.f32": {"dims": [1800,3600], "dtype": "float32"},
@@ -52,7 +52,7 @@
     }
   },
   "scale-letkf": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/SCALE_LETKF/SDRBENCH-SCALE-98x1200x1200.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/SCALE_LETKF/SDRBENCH-SCALE-98x1200x1200.tar.gz",
     "fields": {
       "T-98x1200x1200.f32": {"dims": [98,1200,1200], "dtype": "float32"},
       "PRES-98x1200x1200.f32": {"dims": [98,1200,1200], "dtype": "float32"},
@@ -69,7 +69,7 @@
     }
   },
   "hacc": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/EXASKY/HACC/EXASKY-HACC-data-medium-size.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/EXASKY/HACC/EXASKY-HACC-data-medium-size.tar.gz",
     "fields": {
       "vz.f32": {"dims": [280953867], "dtype": "float32"},
       "vx.f32": {"dims": [280953867], "dtype": "float32"},
@@ -80,7 +80,7 @@
     }
   }, 
   "exaalt-copper": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/EXAALT/SDRBENCH-exaalt-copper.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/EXAALT/SDRBENCH-EXAALT-copper.tar.gz",
     "fields": {
       "dataset1-5423x3137.x.f32.dat": {"dims": [5423, 3137], "dtype": "float32"},
       "dataset1-5423x3137.y.f32.dat": {"dims": [5423, 3137], "dtype": "float32"},
@@ -91,7 +91,7 @@
     }
   }, 
   "exaalt-helium": {
-    "path": "https://g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/EXAALT/SDRBENCH-exaalt-helium.tar.gz",
+    "path": "https://g-d0cd3f.fd635.8443.data.globus.org/raw-data/EXAALT/SDRBENCH-EXAALT-helium.tar.gz",
     "fields": {
       "dataset1-7852x1037.x.f32.dat": {"dims": [7852, 1037], "dtype": "float32"},
       "dataset1-7852x1037.y.f32.dat": {"dims": [7852, 1037], "dtype": "float32"},


### PR DESCRIPTION
Two commits, reviewable separately. The second is folded in here rather than kept as its own PR because the integration-test matrix cannot pass without it — every dataset 404s on `master` today, so the first commit's CI would be red for reasons unrelated to it.

---

## 1. Drop 31 no-op `ALWAYS_INLINE` keywords

`ALWAYS_INLINE` is applied at 49 sites under `include/SZ3/`. Benchmarking says the attribute changes nothing at 31 of them — the compilers already inline those functions, and removing the keyword either yields a byte-identical binary or measures zero.

That matters because a failed `always_inline` is a **hard compile error**, not a warning. Keywords that buy nothing are pure downside: the MinGW CI job on the `fz` branch died exactly this way when MSYS2 moved to GCC 16 and `--param inline-unit-growth` ran out.

### Why this is not a bulk removal

The effect is superadditive, so per-group numbers are misleading. **`LinearQuantizer` (5 sites) and `BlockwiseIterator` (9) carry all of it**: downgrading just those two costs ~7.5%, while downgrading everything else together costs ~0.2%. Neither crosses GCC's inlining threshold alone, so measuring one group at a time shows nothing. Both keep the attribute.

Also kept:

- **`Config.hpp` `to_lower`** — the only namespace-scope non-template among the sites. Without `inline` the library stops linking.
- **`interp_akima` / `interp_pchip`** — multi-line with branches, and currently callerless, so their byte-identical result is vacuous and says nothing about future use.
- **`QuantOptimization.hpp` `lorenzo_predict_3d`** — dead code today, expected to return.

### Deleted, not downgraded

27 of the 31 are in-class definitions (implicitly inline per [class.mfct]/1) and 4 are namespace-scope templates (already weak/COMDAT), so no keyword is needed to preserve linkage. A two-TU link test confirms the classification in both directions, including a negative control that fails as predicted when the `to_lower` keyword is also removed.

Included are the two on `ComposedPredictor::predict`/`estimate_error`, which is where GCC 16 actually hard-errors: the class is itself a `PredictorInterface` and may nest, so speculative devirtualization recurses into it until the inline budget is exhausted.

### Verification

- Compilers: GCC 10.2 / 11.2 / 14.2 and AOCC clang 12 on AMD EPYC 7763; GCC 16.2 and AppleClang locally
- Datasets: Hurricane ISABEL Pf48, Miranda velocityx, plus the in-tree smoke file
- `ALGO_LORENZO_REG`, `ALGO_INTERP_LORENZO`, `ALGO_INTERP`, `ALGO_NOPRED` all round-trip within the error bound; 909 correctness runs showed no behavioural differences
- Unit tests pass under GCC 16.2

---

## 2. Fix SDRBench dataset URLs

All eight integration-test datasets 404. SDRBench moved to a new Globus endpoint, changing both the host and the path prefix:

```
- g-8d6b0.fd635.8443.data.globus.org/ds131.2/Data-Reduction-Repo/raw-data/
+ g-d0cd3f.fd635.8443.data.globus.org/raw-data/
```

`exaalt-copper` and `exaalt-helium` were also renamed upstream, `SDRBENCH-exaalt-*` to `SDRBENCH-EXAALT-*`, so the host swap alone still left those two at 404.

New URLs taken from https://sdrbench.github.io/datasets.html. Verified on #141 before folding in here: **all eight integration tests pass**, which also confirms each archive still unpacks to the filenames `datasets.json` expects — worth checking rather than assuming, given two files were renamed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
