### PR TITLE
Fix 14 pre-existing defects found while working on fz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ install
 .vscode
 sz3_install
 sz3_build
-test
+/test

--- a/include/SZ3/api/impl/SZAlgoBioMD.hpp
+++ b/include/SZ3/api/impl/SZAlgoBioMD.hpp
@@ -1,14 +1,15 @@
 #ifndef SZ3_SZ_BIOMD_HPP
 #define SZ3_SZ_BIOMD_HPP
 
+#include "SZ3/compressor/SZGenericCompressor.hpp"
 #include "SZ3/decomposition/SZBioMDDecomposition.hpp"
 #include "SZ3/decomposition/SZBioMDXtcDecomposition.hpp"
 #include "SZ3/def.hpp"
+#include "SZ3/encoder/HuffmanEncoder.hpp"
+#include "SZ3/encoder/HuffmanEncoderV2.hpp"
 #include "SZ3/encoder/XtcBasedEncoder.hpp"
 #include "SZ3/lossless/Lossless_bypass.hpp"
 #include "SZ3/lossless/Lossless_zstd.hpp"
-#include "SZ3/encoder/HuffmanEncoderV2.hpp"
-#include "SZ3/encoder/HuffmanEncoder.hpp"
 #include "SZ3/quantizer/LinearQuantizer.hpp"
 #include "SZ3/utils/Config.hpp"
 #include "SZ3/utils/Statistic.hpp"

--- a/include/SZ3/api/impl/SZAlgoInterp.hpp
+++ b/include/SZ3/api/impl/SZAlgoInterp.hpp
@@ -1,6 +1,8 @@
 #ifndef SZ3_SZALGO_INTERP_HPP
 #define SZ3_SZALGO_INTERP_HPP
 
+#include <memory>
+
 #include "SZ3/api/impl/SZAlgoLorenzoReg.hpp"
 #include "SZ3/decomposition/BlockwiseDecomposition.hpp"
 #include "SZ3/decomposition/InterpolationDecomposition.hpp"

--- a/include/SZ3/compressor/SZGenericCompressor.hpp
+++ b/include/SZ3/compressor/SZGenericCompressor.hpp
@@ -2,6 +2,7 @@
 #define SZ3_COMPRESSOR_TYPE_ONE_HPP
 
 #include <cstring>
+#include <memory>
 
 #include "SZ3/compressor/Compressor.hpp"
 #include "SZ3/decomposition/Decomposition.hpp"

--- a/include/SZ3/compressor/specialized/SZExaaltCompressor.hpp
+++ b/include/SZ3/compressor/specialized/SZExaaltCompressor.hpp
@@ -1,6 +1,11 @@
 #ifndef SZ3_EXAALT_COMPRESSSOR_HPP
 #define SZ3_EXAALT_COMPRESSSOR_HPP
 
+#include <iostream>
+#include <limits>
+#include <memory>
+
+#include "SZ3/compressor/Compressor.hpp"
 #include "SZ3/def.hpp"
 #include "SZ3/encoder/Encoder.hpp"
 #include "SZ3/lossless/Lossless.hpp"

--- a/include/SZ3/decomposition/BlockwiseDecomposition.hpp
+++ b/include/SZ3/decomposition/BlockwiseDecomposition.hpp
@@ -2,15 +2,17 @@
 #define SZ3_BLOCKWISE_DECOMPOSITION_HPP
 
 #include <cstring>
+#include <limits>
+#include <memory>
 
 #include "Decomposition.hpp"
 #include "SZ3/def.hpp"
 #include "SZ3/predictor/LorenzoPredictor.hpp"
 #include "SZ3/predictor/Predictor.hpp"
 #include "SZ3/quantizer/LinearQuantizer.hpp"
+#include "SZ3/utils/BlockwiseIterator.hpp"
 #include "SZ3/utils/Config.hpp"
 #include "SZ3/utils/FileUtil.hpp"
-#include "SZ3/utils/BlockwiseIterator.hpp"
 #include "SZ3/utils/Timer.hpp"
 
 namespace SZ3 {

--- a/include/SZ3/decomposition/Decomposition.hpp
+++ b/include/SZ3/decomposition/Decomposition.hpp
@@ -1,9 +1,11 @@
 #ifndef SZ3_DECOMPOSITION_INTERFACE
 #define SZ3_DECOMPOSITION_INTERFACE
 
+#include <utility>
 #include <vector>
 
 #include "SZ3/def.hpp"
+#include "SZ3/utils/Config.hpp"
 
 namespace SZ3::concepts {
 

--- a/include/SZ3/decomposition/InterpolationDecomposition.hpp
+++ b/include/SZ3/decomposition/InterpolationDecomposition.hpp
@@ -3,10 +3,12 @@
 
 #include <cmath>
 #include <cstring>
+#include <memory>
 
 #include "Decomposition.hpp"
 #include "SZ3/def.hpp"
 #include "SZ3/quantizer/Quantizer.hpp"
+#include "SZ3/utils/BlockwiseIterator.hpp"
 #include "SZ3/utils/Config.hpp"
 #include "SZ3/utils/FileUtil.hpp"
 #include "SZ3/utils/Interpolators.hpp"
@@ -144,6 +146,11 @@ class InterpolationDecomposition : public concepts::DecompositionInterface<T, in
         quantizer.set_eb(eb);
         quantizer.postcompress_data();
         return quant_inds_vec;
+    }
+
+    size_t size_est() override {
+        return sizeof(original_dimensions) + sizeof(blocksize) + sizeof(interp_id) + sizeof(direction_sequence_id) +
+               sizeof(anchor_stride) + sizeof(eb_alpha) + sizeof(eb_beta) + quantizer_size_est(quantizer) + 128;
     }
 
     void save(uchar *&c) override {

--- a/include/SZ3/decomposition/NoPredictionDecomposition.hpp
+++ b/include/SZ3/decomposition/NoPredictionDecomposition.hpp
@@ -32,6 +32,8 @@ class NoPredictionDecomposition : public concepts::DecompositionInterface<T, int
         return quant_inds;
     }
 
+    size_t size_est() override { return quantizer_size_est(quantizer) + 64; }
+
     void save(uchar *&c) override { quantizer.save(c); }
 
     void load(const uchar *&c, size_t &remaining_length) override { quantizer.load(c, remaining_length); }

--- a/include/SZ3/decomposition/SZBioMDXtcDecomposition.hpp
+++ b/include/SZ3/decomposition/SZBioMDXtcDecomposition.hpp
@@ -6,6 +6,7 @@
 #ifndef SZ3_SZBIOMDXTCBASED_FRONTEND
 #define SZ3_SZBIOMDXTCBASED_FRONTEND
 
+#include <limits>
 #include <list>
 
 #include "Decomposition.hpp"

--- a/include/SZ3/decomposition/TimeSeriesDecomposition.hpp
+++ b/include/SZ3/decomposition/TimeSeriesDecomposition.hpp
@@ -1,6 +1,9 @@
 #ifndef SZ3_TIME_SERIES_DECOMPOSITION_HPP
 #define SZ3_TIME_SERIES_DECOMPOSITION_HPP
 
+#include <cassert>
+#include <limits>
+
 #include "Decomposition.hpp"
 #include "SZ3/def.hpp"
 #include "SZ3/predictor/LorenzoPredictor.hpp"
@@ -34,6 +37,9 @@ public:
     std::vector<int> compress(const Config& conf, T* data) override {
         std::vector<int> quant_inds(num_elements);
         size_t quant_count = 0;
+        // The timestep loop below predicts from the reconstruction of timestep 0.
+        const T* ts0_recon = data;
+        std::shared_ptr<block_data<T, N - 1>> data_with_padding;
         if (data_ts0 != nullptr) {
             for (size_t j = 0; j < conf.dims[1]; j++) {
                 quant_inds[quant_count++] = quantizer.quantize_and_overwrite(data[j], data_ts0[j]);
@@ -44,7 +50,7 @@ public:
                 spatial_dims[i] = conf.dims[i + 1];
             };
 
-            auto data_with_padding =
+            data_with_padding =
                 std::make_shared<block_data<T, N - 1>>(data, spatial_dims, predictor.get_padding(), true);
             auto block = data_with_padding->block_iter(conf.blockSize);
             do {
@@ -58,13 +64,16 @@ public:
                     quant_inds[quant_count++] = quantizer.quantize_and_overwrite(*c, pred);
                 });
             } while (block.next());
+
+            ts0_recon = data_with_padding->values();
         }
 
         for (size_t j = 0; j < conf.dims[1]; j++) {
+            T prev = ts0_recon[j];
             for (size_t i = 1; i < conf.dims[0]; i++) {
                 size_t idx = i * conf.dims[1] + j;
-                size_t idx_prev = (i - 1) * conf.dims[1] + j;
-                quant_inds[quant_count++] = quantizer.quantize_and_overwrite(data[idx], data[idx_prev]);
+                quant_inds[quant_count++] = quantizer.quantize_and_overwrite(data[idx], prev);
+                prev = data[idx];  // quantize_and_overwrite left the reconstruction here
             }
         }
         assert(quant_count == num_elements);

--- a/include/SZ3/encoder/ArithmeticEncoder.hpp
+++ b/include/SZ3/encoder/ArithmeticEncoder.hpp
@@ -2,6 +2,7 @@
 #define SZ3_ArithmeticEncoder_HPP
 
 #include <cassert>
+#include <cmath>
 #include <iostream>
 
 #include "SZ3/encoder/Encoder.hpp"
@@ -527,7 +528,7 @@ class ArithmeticEncoder : public concepts::EncoderInterface<T> {
         size_t total_frequency = ariCoder.total_frequency;
         const uchar *sp = bytes + 5;
         unsigned int offset = 4;
-        size_t value = (bytesToInt64_bigEndian(bytes) >> 20);  // alignment with the MAX_CODE
+        size_t value = (static_cast<uint64_t>(bytesToInt64_bigEndian(bytes)) >> 20);  // alignment with the MAX_CODE
         size_t s_counter = sizeof(int);
 
         for (i = 0; i < targetLength; i++) {

--- a/include/SZ3/encoder/HuffmanEncoder.hpp
+++ b/include/SZ3/encoder/HuffmanEncoder.hpp
@@ -533,6 +533,10 @@ class HuffmanEncoder : public concepts::EncoderInterface<T> {
             }
         }
 
+        // The state table is sized by the bin range, not the distinct count.
+        if (static_cast<double>(max) - static_cast<double>(offset) > 2e9) {
+            throw std::invalid_argument("HuffmanEncoder: bin range too wide; use HuffmanEncoderV2");
+        }
         int stateNum = max - offset + 2;
         huffmanTree = createHuffmanTree(stateNum);
 

--- a/include/SZ3/encoder/RunlengthEncoder.hpp
+++ b/include/SZ3/encoder/RunlengthEncoder.hpp
@@ -12,7 +12,9 @@ namespace SZ3 {
 template <class T>
 class RunlengthEncoder : public concepts::EncoderInterface<T> {
    public:
-    void preprocess_encode(const std::vector<T> &bins, int stateNum) override {}
+    void preprocess_encode(const std::vector<T> &bins, int stateNum) override { num_bins = bins.size(); }
+
+    size_t size_est() override { return num_bins * (sizeof(T) + sizeof(int)); }
 
     size_t encode(const std::vector<T> &bins, uchar *&bytes) override {
         auto bytespos = bytes;
@@ -60,6 +62,8 @@ class RunlengthEncoder : public concepts::EncoderInterface<T> {
     void save(uchar *&c) override {}
 
     void load(const uchar *&c, size_t &remaining_length) override {}
+
+    size_t num_bins = 0;  ///< Set by preprocess_encode(), consumed by size_est()
 };
 }  // namespace SZ3
 #endif

--- a/include/SZ3/encoder/XtcBasedEncoder.hpp
+++ b/include/SZ3/encoder/XtcBasedEncoder.hpp
@@ -9,10 +9,12 @@
 #define _SZ_XTC3_ENCODER_HPP
 
 #include <climits>
+#include <cmath>
 #include <vector>
 
 #include "SZ3/def.hpp"
 #include "SZ3/encoder/Encoder.hpp"
+#include "SZ3/utils/Config.hpp"
 
 // #define DEBUG_OUTPUT
 

--- a/include/SZ3/lossless/Lossless.hpp
+++ b/include/SZ3/lossless/Lossless.hpp
@@ -5,6 +5,10 @@
 #ifndef SZ3_LOSSLESS_HPP
 #define SZ3_LOSSLESS_HPP
 
+#include <cstddef>
+
+#include "SZ3/def.hpp"
+
 namespace SZ3::concepts {
 
 /**

--- a/include/SZ3/lossless/Lossless_bypass.hpp
+++ b/include/SZ3/lossless/Lossless_bypass.hpp
@@ -5,16 +5,21 @@
 #ifndef SZ3_LOSSLESS_BYPASS_HPP
 #define SZ3_LOSSLESS_BYPASS_HPP
 
+#include <cstdlib>
 #include <cstring>
+#include <stdexcept>
+
 #include "SZ3/def.hpp"
 #include "SZ3/lossless/Lossless.hpp"
 
 namespace SZ3 {
 class Lossless_bypass : public concepts::LosslessInterface {
-public:
+   public:
     size_t compress(const uchar *src, size_t srcLen, uchar *dst, size_t dstCap) override {
+        if (dstCap < srcLen) {
+            throw std::length_error(SZ3_ERROR_COMP_BUFFER_NOT_LARGE_ENOUGH);
+        }
         std::memcpy(dst, src, srcLen);
-        // dst = src;
         return srcLen;
     }
 

--- a/include/SZ3/predictor/LorenzoPredictor.hpp
+++ b/include/SZ3/predictor/LorenzoPredictor.hpp
@@ -1,6 +1,9 @@
 #ifndef SZ3_LORENZO_PREDICTOR_HPP
 #define SZ3_LORENZO_PREDICTOR_HPP
 
+#include <iostream>
+#include <limits>
+
 #include "SZ3/predictor/Predictor.hpp"
 
 namespace SZ3 {

--- a/include/SZ3/predictor/RegressionPredictor.hpp
+++ b/include/SZ3/predictor/RegressionPredictor.hpp
@@ -114,9 +114,11 @@ class RegressionPredictor : public concepts::PredictorInterface<T, N> {
             quantizer_liner.load(c, remaining_length);
             HuffmanEncoder<int> encoder = HuffmanEncoder<int>();
             encoder.load(c, remaining_length);
+            const uchar *coeff_start = c;
             regression_coeff_quant_inds = encoder.decode(c, coeff_size);
             encoder.postprocess_decode();
-            remaining_length -= coeff_size * sizeof(int);
+            // decode() advances `c` by the encoded byte count, not by the decoded bin count.
+            remaining_length -= static_cast<size_t>(c - coeff_start);
             std::fill(current_coeffs.begin(), current_coeffs.end(), 0);
             regression_coeff_index = 0;
         }

--- a/include/SZ3/preprocessor/PreFilter.hpp
+++ b/include/SZ3/preprocessor/PreFilter.hpp
@@ -5,6 +5,10 @@
 #ifndef SZ3_PREFILTER_HPP
 #define SZ3_PREFILTER_HPP
 
+#include <array>
+#include <cstddef>
+#include <vector>
+
 #include "SZ3/preprocessor/PreProcessor.hpp"
 
 namespace SZ3 {

--- a/include/SZ3/preprocessor/Transpose.hpp
+++ b/include/SZ3/preprocessor/Transpose.hpp
@@ -5,6 +5,10 @@
 #ifndef SZ3_TRANSPOSE_H
 #define SZ3_TRANSPOSE_H
 
+#include <array>
+#include <cstddef>
+#include <vector>
+
 #include "SZ3/preprocessor/PreProcessor.hpp"
 
 namespace SZ3 {

--- a/include/SZ3/quantizer/LinearQuantizer.hpp
+++ b/include/SZ3/quantizer/LinearQuantizer.hpp
@@ -83,7 +83,12 @@ public:
         return pred + 2 * (quant_index - this->radius) * this->error_bound;
     }
 
-    ALWAYS_INLINE T recover_unpred() { return unpred[index++]; }
+    ALWAYS_INLINE T recover_unpred() {
+        if (index >= unpred.size()) {
+            throw std::runtime_error("LinearQuantizer: more unpredictable bins than stored values");
+        }
+        return unpred[index++];
+    }
 
     ALWAYS_INLINE int force_save_unpred(T ori) override {
         unpred.push_back(ori);

--- a/include/SZ3/quantizer/Quantizer.hpp
+++ b/include/SZ3/quantizer/Quantizer.hpp
@@ -2,6 +2,9 @@
 #define SZ3_QUANTIZER_HPP
 
 #include <SZ3/def.hpp>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
 
 namespace SZ3::concepts {
 
@@ -69,5 +72,23 @@ class   QuantizerInterface {
     virtual void print() {}
 };
 }  // namespace SZ3::concepts
+
+namespace SZ3 {
+/// Detects the optional (non-virtual) `size_est()` some quantizers expose.
+template <class Q, class = void>
+struct quantizer_has_size_est : std::false_type {};
+template <class Q>
+struct quantizer_has_size_est<Q, std::void_t<decltype(std::declval<Q &>().size_est())>> : std::true_type {};
+
+/// The quantizer's serialized-size estimate, or 0 when it does not expose one.
+template <class Q>
+size_t quantizer_size_est(Q &q) {
+    if constexpr (quantizer_has_size_est<Q>::value) {
+        return q.size_est();
+    } else {
+        return 0;
+    }
+}
+}  // namespace SZ3
 
 #endif

--- a/include/SZ3/utils/BlockwiseIterator.hpp
+++ b/include/SZ3/utils/BlockwiseIterator.hpp
@@ -4,11 +4,14 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
+
+#include "SZ3/def.hpp"
 
 namespace SZ3 {
 
@@ -219,6 +222,23 @@ class block_data : public std::enable_shared_from_this<block_data<T, N>> {
         }
     }
 
+    /**
+     * @brief The block's values in unpadded layout.
+     *
+     * Without padding this is the array this object was constructed from. With padding it is an
+     * internal copy, materialized on the first call and valid until this object is destroyed.
+     *
+     * @return Pointer to `num` elements
+     */
+    const T *values() {
+        if (padding == 0 || internal_buffer.empty()) {
+            return data_padding;
+        }
+        unpadded_buffer.resize(num);
+        copy_data_with_padding(unpadded_buffer.data(), ds, data_padding, ds_padding, dims);
+        return unpadded_buffer.data();
+    }
+
     block_iterator block_iter(size_t block_size) { return block_iterator(this->shared_from_this(), block_size); }
 
    protected:
@@ -273,6 +293,7 @@ class block_data : public std::enable_shared_from_this<block_data<T, N>> {
     std::array<size_t, N> dims;            // dimension
     std::array<size_t, N> ds, ds_padding;  // stride
     std::vector<T> internal_buffer;
+    std::vector<T> unpadded_buffer;  // materialized on demand by values()
     T *data_cp_dst = nullptr;
     T *data_padding;  // point to either data_ or internal_buffer depending on padding
     size_t padding;

--- a/include/SZ3/utils/Extraction.hpp
+++ b/include/SZ3/utils/Extraction.hpp
@@ -5,6 +5,14 @@
 #ifndef SZ3_EXTRACTION_HPP
 #define SZ3_EXTRACTION_HPP
 
+#include <algorithm>
+#include <cassert>
+#include <numeric>
+#include <vector>
+
+#include "SZ3/def.hpp"
+#include "SZ3/utils/Timer.hpp"
+
 namespace SZ3 {
 
 template <uint N>

--- a/include/SZ3/utils/Iterator.hpp
+++ b/include/SZ3/utils/Iterator.hpp
@@ -14,6 +14,8 @@
 #include <typeinfo>
 #include <vector>
 
+#include "SZ3/def.hpp"
+
 namespace SZ3 {
 // N-dimensional multi_dimensional_range
 template <class T, uint N>

--- a/include/SZ3/utils/KmeansUtil.hpp
+++ b/include/SZ3/utils/KmeansUtil.hpp
@@ -292,7 +292,7 @@ void get_cluster(T *data, size_t num, float &level_start, float &level_offset, i
     if (num == sample_num) {
         sample = std::vector<T>(data, data + num);
     } else {
-        sample.reserve(sample_num);
+        sample.resize(sample_num);  // the loop below writes through operator[]
         std::random_device rd;   // Will be used to obtain a seed for the random number engine
         std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
         //        std::uniform_int_distribution<> dis(0, 2 * sample_rate);
@@ -303,7 +303,7 @@ void get_cluster(T *data, size_t num, float &level_start, float &level_offset, i
         //            sample[i] = input[input_idx];
         //        }
         //        std::cout << std::endl;
-        std::uniform_int_distribution<> dis2(0, num);
+        std::uniform_int_distribution<> dis2(0, static_cast<int>(num) - 1);
         std::unordered_set<size_t> sampledkeys;
         //            printf("total_num=%lu, sample_num=%lu\n", num, sample_num);
         for (size_t i = 0; i < sample_num; i++) {

--- a/include/SZ3/utils/MemoryUtil.hpp
+++ b/include/SZ3/utils/MemoryUtil.hpp
@@ -5,9 +5,9 @@
 #ifndef SZ3_MEMORYOPS_HPP
 #define SZ3_MEMORYOPS_HPP
 
-#include <cassert>
-#include <cstring>
 #include <cstdint>
+#include <cstring>
+#include <stdexcept>
 
 #include "SZ3/def.hpp"
 
@@ -73,7 +73,9 @@ inline T byteswap(T value) {
 // read array
 template <class T1>
 void read(T1 *array, size_t num_elements, uchar const *&compressed_data_pos, size_t &remaining_length) {
-    assert(num_elements * sizeof(T1) <= remaining_length);
+    if (num_elements * sizeof(T1) > remaining_length) {
+        throw std::invalid_argument("SZ3: compressed stream is truncated");
+    }
     memcpy(array, compressed_data_pos, num_elements * sizeof(T1));
     if constexpr (SZ3_BIG_ENDIAN) {
         for (size_t i = 0; i < num_elements; i++) {
@@ -109,7 +111,9 @@ void read(T1 &var, uchar const *&compressed_data_pos) {
 // read variable
 template <class T1>
 void read(T1 &var, uchar const *&compressed_data_pos, size_t &remaining_length) {
-    assert(sizeof(T1) <= remaining_length);
+    if (sizeof(T1) > remaining_length) {
+        throw std::invalid_argument("SZ3: compressed stream is truncated");
+    }
     memcpy(&var, compressed_data_pos, sizeof(T1));
     if constexpr (SZ3_BIG_ENDIAN) {
         var = byteswap(var);

--- a/include/SZ3/utils/QuantOptimization.hpp
+++ b/include/SZ3/utils/QuantOptimization.hpp
@@ -1,7 +1,10 @@
 #ifndef SZ3_optimize_quant_intervals_hpp
 #define SZ3_optimize_quant_intervals_hpp
 
+#include <cmath>
 #include <vector>
+
+#include "SZ3/def.hpp"
 
 namespace SZ3 {
 

--- a/include/SZ3/utils/Sample.hpp
+++ b/include/SZ3/utils/Sample.hpp
@@ -1,8 +1,10 @@
 #ifndef SZ3_SAMPLE_HPP
 #define SZ3_SAMPLE_HPP
 
-#include "SZ3/def.hpp"
+#include <cassert>
 #include <vector>
+
+#include "SZ3/def.hpp"
 
 namespace SZ3 {
 template <class T, uint N>

--- a/include/SZ3/utils/Statistic.hpp
+++ b/include/SZ3/utils/Statistic.hpp
@@ -5,6 +5,10 @@
 #ifndef SZ3_STATISTIC_HPP
 #define SZ3_STATISTIC_HPP
 
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
 #include "Config.hpp"
 
 namespace SZ3 {

--- a/tools/H5Z-SZ3/src/H5Z_SZ3.cpp
+++ b/tools/H5Z-SZ3/src/H5Z_SZ3.cpp
@@ -1,5 +1,6 @@
 #include "H5Z_SZ3.hpp"
 
+#include <algorithm>
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -159,7 +160,10 @@ void process_data(SZ3::Config& conf, void** buf, size_t* buf_size, size_t nbytes
         *buf = processedData;
         *buf_size = conf.num * sizeof(T);
     } else {
-        size_t cmpCap = sizeof(T) * conf.num * 2;
+        // SZ_compress rejects anything below its own bound, which small chunks fall under; that
+        // bound assumes the payload fits in the raw size, so keep the old headroom on top of it
+        // for algorithms whose output can approach or exceed it.
+        size_t cmpCap = std::max(SZ3::SZ_compress_size_bound<T>(conf), sizeof(T) * conf.num * 2);
         char* cmpData = static_cast<char*>(malloc(cmpCap));
         *buf_size = SZ_compress(conf, static_cast<T*>(*buf), cmpData, cmpCap);
         free(*buf);


### PR DESCRIPTION
Every defect below was found while working on the `fz` branch and then verified to reproduce on `master`. None of the new `fz` modules are included — this is only the fixes to code `master` already has.

## Memory safety

| Module | Defect |
|---|---|
| `Lossless_bypass::compress` | memcpy'd `srcLen` bytes into `dst` regardless of `dstCap`, so any payload larger than the caller's buffer was an unconditional heap overflow. `Lossless_zstd` already checks and throws; bypass now does the same. Caught by AddressSanitizer on Linux: `ALGO_BIOMDXTC` is the one algorithm that pairs its codec with `Lossless_bypass`, so nothing shrinks the payload, and glibc reported it as `munmap_chunk(): invalid pointer`. macOS's allocator does not abort on it. |
| `MemoryUtil::read` | `remaining_length` was guarded by `assert`, which Release compiles out, so a truncated or corrupt stream read past the end of the buffer. Now throws. |
| `RegressionPredictor::load` | debited `remaining_length` by `coeff_size * sizeof(int)` (the decoded bin count) while `decode()` advances the cursor by the much smaller encoded byte count, so the budget ran out early. This is what the `MemoryUtil` guard was hiding: on the HDF5 filter path with `ALGO_LORENZO_REG` at `eb = 1e-4` it read past the buffer on every miranda velocity field. |
| `LinearQuantizer::recover_unpred` | no bounds check on the unpredictable list, so a stream with more zero bins than stored values read past the end. |
| `RunlengthEncoder` | no `size_est()`, so `SZGenericCompressor` sized its buffer without accounting for the encoder and `encode()` overran it. |
| `KmeansUtil` | `reserve()` followed by `operator[]` writes (UB), and `uniform_int_distribution(0, num)` indexing `data[num]`. Live in `mdz` when `dims[1] > 5000`. |
| `H5Z-SZ3` | sized the compressed buffer as `sizeof(T) * num * 2`, which is below `SZ_compress`'s own minimum for a small chunk. An explicit chunk of a few hundred elements aborted with "The buffer for compressed data is not large enough". |
| `NoPredictionDecomposition`, `InterpolationDecomposition` | no `size_est()` override, so the compressor sized its buffer from 0 while the quantizer's unpredictable list could be arbitrarily large. |

## Correctness

| Module | Defect |
|---|---|
| `TimeSeriesDecomposition` | with `data_ts0 == nullptr` the timestep loop predicted from stale values: `block_data`'s compress-side path has no write-back, so timestep 0 in `data` was never updated with its reconstruction while `decompress()` predicted from its own. Measured **1.94x the error bound**; 0.997x after the fix. |
| `ArithmeticEncoder` | `bytesToInt64_bigEndian(bytes) >> 20` sign-extends when the top byte's MSB is set, pushing the value outside the 44-bit `MAX_CODE` window. A 60-stream sweep gave 30 correct, 23 wrong, 7 SIGSEGV. |
| `HuffmanEncoder` | `stateNum = max - offset + 2` narrows to `int`, so a wide bin range goes negative and the state-table `malloc` is UB. Now throws and points at `HuffmanEncoderV2`, which switches to a sparse map. |

## Portability

- **6 headers** used `std::make_shared` without `<memory>`. libc++ provides it transitively and libstdc++ does not, so this is latent until a translation unit changes its include order — it broke the Linux build on `fz` once a new test file changed the include order.
- **24 headers** were not self-contained under one or both standard libraries (missing `<limits>`, `<cmath>`, `<cstddef>`, `<array>`, `SZ3/def.hpp`, or a project header). All 57 now compile standalone under both clang/libc++ and GCC 16/libstdc++. The script that checks this lives on the `fz` branch (`tools/test/check_headers.py`) and is not part of this PR.
- `.gitignore`'s bare `test` pattern matched `tools/test/`, hiding every test file from git. Now `/test`.

## Verification

- clang and GCC 16, Release + `BUILD_TESTING=ON` + `BUILD_H5Z_FILTER=ON`: 0 errors, 0 warnings, all tests pass
- Compressed output for the default algorithm is unchanged
- Each fix was A/B'd against its unfixed state; the `TimeSeriesDecomposition` and `H5Z-SZ3` numbers above are from those runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
